### PR TITLE
fix(security): close nonce replay window, freeze $auth.session, strict authorize return (fixes #4)

### DIFF
--- a/packages/core/src/__tests__/auth/auth-manager-authorize.test.ts
+++ b/packages/core/src/__tests__/auth/auth-manager-authorize.test.ts
@@ -302,7 +302,9 @@ describe('LiveAuthManager - authorize()', () => {
       const session = { id: 'sess-1', roles: ['editor'], permissions: ['edit'] }
       const ctx = new AuthenticatedContext(session, 'tok')
 
-      expect(ctx.session).toBe(session)
+      // Session is defensively copied and frozen (issue #4 fix), so it is
+      // not the same reference as the input — but the contents must match.
+      expect(ctx.session).toEqual(session)
       expect(ctx.session.id).toBe('sess-1')
       expect(ctx.session.roles).toEqual(['editor'])
     })
@@ -311,6 +313,8 @@ describe('LiveAuthManager - authorize()', () => {
       const session = { id: 'sess-2', roles: ['admin'] }
       const ctx = new AuthenticatedContext(session)
 
+      // `user` is a deprecated alias getter for `session`; they must resolve
+      // to the same (frozen) object stored inside the context.
       expect(ctx.user).toBe(ctx.session)
     })
 

--- a/packages/core/src/__tests__/auth/authorize-strict-return.test.ts
+++ b/packages/core/src/__tests__/auth/authorize-strict-return.test.ts
@@ -1,0 +1,118 @@
+// Regression test for issue #4 (part 3): strict validation of the value
+// returned from a user-supplied `authorize()` callback.
+//
+// Before the fix, LiveAuthManager treated any non-boolean return as a
+// LiveAuthResult, so primitives like `'true'`, `0`, `null` or `undefined`
+// were stored in `result.allowed` as `undefined`. Downstream code that
+// checked `result.allowed === false` (strict equality) would miss the
+// deny and allow the action. Now we coerce unknown shapes to a deny.
+
+import { describe, it, expect } from 'vitest'
+import { LiveAuthManager } from '../../auth/LiveAuthManager'
+import { AuthenticatedContext } from '../../auth/LiveAuthContext'
+import type { LiveActionAuth, LiveComponentAuth } from '../../auth/types'
+
+describe('LiveAuthManager — strict authorize() return coercion (issue #4 part 3)', () => {
+  const user = () => new AuthenticatedContext({ id: 'u', roles: ['user'] })
+
+  describe('authorizeAction', () => {
+    it('boolean true → allowed', async () => {
+      const mgr = new LiveAuthManager()
+      const cfg: LiveActionAuth = { authorize: (async () => true) as any }
+      const r = await mgr.authorizeAction(user(), 'C', 'a', cfg)
+      expect(r.allowed).toBe(true)
+    })
+
+    it('boolean false → denied with explicit allowed:false', async () => {
+      const mgr = new LiveAuthManager()
+      const cfg: LiveActionAuth = { authorize: (async () => false) as any }
+      const r = await mgr.authorizeAction(user(), 'C', 'a', cfg)
+      expect(r.allowed).toBe(false)
+      // Strict consumers checking === false must work.
+      expect(r.allowed === false).toBe(true)
+    })
+
+    it('{ allowed: true } → allowed', async () => {
+      const mgr = new LiveAuthManager()
+      const cfg: LiveActionAuth = { authorize: (async () => ({ allowed: true })) as any }
+      const r = await mgr.authorizeAction(user(), 'C', 'a', cfg)
+      expect(r.allowed).toBe(true)
+    })
+
+    it('{ allowed: false, reason } → denied with preserved reason', async () => {
+      const mgr = new LiveAuthManager()
+      const cfg: LiveActionAuth = {
+        authorize: (async () => ({ allowed: false, reason: 'no dice' })) as any,
+      }
+      const r = await mgr.authorizeAction(user(), 'C', 'a', cfg)
+      expect(r.allowed).toBe(false)
+      expect(r.reason).toBe('no dice')
+    })
+
+    it('undefined → denied (fail-closed, strict false)', async () => {
+      const mgr = new LiveAuthManager()
+      const cfg: LiveActionAuth = { authorize: (async () => undefined) as any }
+      const r = await mgr.authorizeAction(user(), 'C', 'a', cfg)
+      expect(r.allowed === false).toBe(true) // strict check, not just falsy
+    })
+
+    it('null → denied', async () => {
+      const mgr = new LiveAuthManager()
+      const cfg: LiveActionAuth = { authorize: (async () => null) as any }
+      const r = await mgr.authorizeAction(user(), 'C', 'a', cfg)
+      expect(r.allowed === false).toBe(true)
+    })
+
+    it('number 0 → denied', async () => {
+      const mgr = new LiveAuthManager()
+      const cfg: LiveActionAuth = { authorize: (async () => 0) as any }
+      const r = await mgr.authorizeAction(user(), 'C', 'a', cfg)
+      expect(r.allowed === false).toBe(true)
+    })
+
+    it('string "true" → denied (truthy primitive must not bypass)', async () => {
+      const mgr = new LiveAuthManager()
+      const cfg: LiveActionAuth = { authorize: (async () => 'true') as any }
+      const r = await mgr.authorizeAction(user(), 'C', 'a', cfg)
+      expect(r.allowed === false).toBe(true)
+      expect(typeof r).toBe('object') // must be a real LiveAuthResult, not a string
+    })
+
+    it('object without allowed key → denied', async () => {
+      const mgr = new LiveAuthManager()
+      const cfg: LiveActionAuth = { authorize: (async () => ({ foo: 'bar' })) as any }
+      const r = await mgr.authorizeAction(user(), 'C', 'a', cfg)
+      expect(r.allowed === false).toBe(true)
+    })
+
+    it('object with allowed: "yes" (wrong type) → denied', async () => {
+      const mgr = new LiveAuthManager()
+      const cfg: LiveActionAuth = { authorize: (async () => ({ allowed: 'yes' })) as any }
+      const r = await mgr.authorizeAction(user(), 'C', 'a', cfg)
+      expect(r.allowed === false).toBe(true)
+    })
+  })
+
+  describe('authorizeComponent', () => {
+    it('undefined → denied', async () => {
+      const mgr = new LiveAuthManager()
+      const cfg: LiveComponentAuth = { authorize: (async () => undefined) as any }
+      const r = await mgr.authorizeComponent(user(), cfg)
+      expect(r.allowed === false).toBe(true)
+    })
+
+    it('boolean true → allowed', async () => {
+      const mgr = new LiveAuthManager()
+      const cfg: LiveComponentAuth = { authorize: (async () => true) as any }
+      const r = await mgr.authorizeComponent(user(), cfg)
+      expect(r.allowed).toBe(true)
+    })
+
+    it('{ allowed: true } → allowed', async () => {
+      const mgr = new LiveAuthManager()
+      const cfg: LiveComponentAuth = { authorize: (async () => ({ allowed: true })) as any }
+      const r = await mgr.authorizeComponent(user(), cfg)
+      expect(r.allowed).toBe(true)
+    })
+  })
+})

--- a/packages/core/src/__tests__/auth/session-freeze.test.ts
+++ b/packages/core/src/__tests__/auth/session-freeze.test.ts
@@ -1,0 +1,82 @@
+// Regression test for issue #4 (part 2): $auth.session mutability.
+//
+// Before the fix, AuthenticatedContext stored `session` by reference and
+// did not freeze it, so a handler bug that mutated `this.$auth.session.roles`
+// or `.id` silently altered subsequent authorize() decisions within the
+// same process. The fix deep-copies and freezes the session (plus the
+// roles/permissions arrays) and freezes the context instance itself.
+
+import { describe, it, expect } from 'vitest'
+import { AuthenticatedContext, ANONYMOUS_CONTEXT } from '../../auth/LiveAuthContext'
+
+describe('AuthenticatedContext — session immutability (issue #4 part 2)', () => {
+  it('direct mutation of session.id throws in strict mode and has no effect', () => {
+    const ctx = new AuthenticatedContext({ id: 'alice', roles: ['user'] })
+    expect(() => {
+      ;(ctx.session as any).id = 'bob'
+    }).toThrow(TypeError)
+    expect(ctx.session.id).toBe('alice')
+  })
+
+  it('assignment to session.roles (replacing the array) throws and leaves the array intact', () => {
+    const ctx = new AuthenticatedContext({ id: 'alice', roles: ['user'] })
+    expect(() => {
+      ;(ctx.session as any).roles = ['admin']
+    }).toThrow(TypeError)
+    expect(ctx.session.roles).toEqual(['user'])
+  })
+
+  it('pushing onto session.roles throws — privilege escalation via mutation is blocked', () => {
+    const ctx = new AuthenticatedContext({ id: 'alice', roles: ['user'] })
+    expect(() => {
+      ;(ctx.session.roles as any).push('admin')
+    }).toThrow(TypeError)
+    expect(ctx.hasRole('admin')).toBe(false)
+    expect(ctx.hasRole('user')).toBe(true)
+  })
+
+  it('pushing onto session.permissions throws', () => {
+    const ctx = new AuthenticatedContext({ id: 'alice', permissions: ['read'] })
+    expect(() => {
+      ;(ctx.session.permissions as any).push('write')
+    }).toThrow(TypeError)
+    expect(ctx.hasPermission('write')).toBe(false)
+  })
+
+  it('mutating the original source object after construction does not leak into the context', () => {
+    // The constructor copies roles/permissions — so mutating the caller's
+    // original object cannot affect what the context sees.
+    const source = { id: 'alice', roles: ['user'] as string[], permissions: ['read'] as string[] }
+    const ctx = new AuthenticatedContext(source)
+    source.roles.push('admin')
+    source.permissions.push('write')
+    expect(ctx.session.roles).toEqual(['user'])
+    expect(ctx.session.permissions).toEqual(['read'])
+    expect(ctx.hasRole('admin')).toBe(false)
+    expect(ctx.hasPermission('write')).toBe(false)
+  })
+
+  it('the context instance itself is frozen — cannot replace session', () => {
+    const ctx = new AuthenticatedContext({ id: 'alice', roles: ['user'] })
+    expect(() => {
+      ;(ctx as any).session = { id: 'bob', roles: ['admin'] }
+    }).toThrow(TypeError)
+    expect(ctx.session.id).toBe('alice')
+  })
+
+  it('ANONYMOUS_CONTEXT singleton is frozen', () => {
+    expect(Object.isFrozen(ANONYMOUS_CONTEXT)).toBe(true)
+    expect(() => {
+      ;(ANONYMOUS_CONTEXT as any).authenticated = true
+    }).toThrow(TypeError)
+    expect(ANONYMOUS_CONTEXT.authenticated).toBe(false)
+  })
+
+  it('sessions without roles/permissions still freeze cleanly', () => {
+    const ctx = new AuthenticatedContext({ id: 'u' })
+    expect(Object.isFrozen(ctx.session)).toBe(true)
+    expect(Object.isFrozen(ctx)).toBe(true)
+    // Without roles, hasRole is trivially false; this must not throw.
+    expect(ctx.hasRole('admin')).toBe(false)
+  })
+})

--- a/packages/core/src/__tests__/security/StateSignature.replay-eviction.test.ts
+++ b/packages/core/src/__tests__/security/StateSignature.replay-eviction.test.ts
@@ -1,0 +1,161 @@
+// Regression tests for issue #4 (replay attack via nonce eviction).
+//
+// Before the fix, when the usedNonces Map exceeded MAX_NONCES the manager
+// would evict the oldest 10% of entries by insertion order. Since those
+// entries could still be within nonceTTL, an attacker holding a previously
+// captured SignedState could replay it after forcing the map to fill.
+//
+// Fix: track a high-water mark of the newest *embedded* timestamp we ever
+// evicted. Any subsequent nonce whose embedded timestamp is at or before
+// that mark is rejected as "predates replay-protection window".
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { StateSignatureManager } from '../../security/StateSignature'
+
+describe('StateSignature — replay protection across nonce eviction (issue #4)', () => {
+  let mgr: StateSignatureManager
+
+  beforeEach(() => {
+    mgr = new StateSignatureManager({
+      secret: 'test-secret-1234567890123456',
+      nonceEnabled: true,
+      // Generous TTL so we never fail validation for unrelated age reasons.
+      nonceTTL: 10 * 60 * 1000,
+    })
+  })
+
+  /** Seed the usedNonces Map with synthetic entries whose embedded ts is
+   *  comfortably in the past but still within TTL. Keyed in the real
+   *  `ts:rand:mac` format so the eviction path can parse the embedded ts. */
+  function seedSyntheticNonces(count: number, baseTs: number): void {
+    const map = (mgr as any).usedNonces as Map<string, number>
+    for (let i = 0; i < count; i++) {
+      const ts = baseTs + i
+      const key = `${ts}:aaaaaaaaaaaaaaaa:0000000000000000`
+      map.set(key, Date.now())
+    }
+  }
+
+  it('replay of an already-used nonce is blocked (baseline)', () => {
+    const signed = mgr.signState('c', { a: 1 }, 1)
+    expect(mgr.validateState(signed).valid).toBe(true)
+    const replay = mgr.validateState(signed)
+    expect(replay.valid).toBe(false)
+    expect(replay.error).toMatch(/already used/i)
+  })
+
+  it('replay is blocked even after the nonce is manually cleared from the map', () => {
+    // Simulates the post-eviction scenario the bug exploited: the attacker's
+    // nonce is gone from usedNonces but still cryptographically valid and
+    // within TTL. With the fix, the high-water mark should reject it.
+    const signed = mgr.signState('c', { a: 1 }, 1)
+    expect(mgr.validateState(signed).valid).toBe(true)
+
+    // Force the manager into "just evicted through this ts" state.
+    const attackerTs = Number(signed.nonce!.split(':')[0])
+    ;(mgr as any).usedNonces.clear()
+    ;(mgr as any).evictionHighWaterMark = attackerTs
+
+    const replay = mgr.validateState(signed)
+    expect(replay.valid).toBe(false)
+    expect(replay.error).toMatch(/predates replay-protection window/)
+  })
+
+  it('evictOldNoncesIfNeeded advances the high-water mark to the newest evicted embedded ts', () => {
+    const baseTs = Date.now() - 60_000
+    // Seed just over the cap so eviction has to remove ~10% (= 10_000 entries).
+    const MAX = (StateSignatureManager as any).MAX_NONCES as number
+    seedSyntheticNonces(MAX + 1, baseTs)
+
+    // Trigger eviction via the private method (what validateState does too).
+    ;(mgr as any).evictOldNoncesIfNeeded()
+
+    const mark = (mgr as any).evictionHighWaterMark as number
+    // Eviction removes 10% by insertion order, so the newest evicted ts is
+    // (baseTs + floor((MAX + 1) * 0.1) - 1).
+    const expectedEvicted = Math.floor((MAX + 1) * 0.1)
+    expect(mark).toBe(baseTs + expectedEvicted - 1)
+  })
+
+  it('a fresh nonce signed after an eviction still validates (no false positives)', () => {
+    // Seed with ancient entries, evict, then sign a new state and check it.
+    const ancientBase = Date.now() - 5 * 60_000
+    const MAX = (StateSignatureManager as any).MAX_NONCES as number
+    seedSyntheticNonces(MAX + 1, ancientBase)
+    ;(mgr as any).evictOldNoncesIfNeeded()
+
+    const mark = (mgr as any).evictionHighWaterMark as number
+    expect(mark).toBeGreaterThan(0)
+    expect(mark).toBeLessThan(Date.now()) // well in the past
+
+    // New sign uses Date.now() which is > mark → must validate.
+    const fresh = mgr.signState('c', { hello: 'world' }, 1)
+    const result = mgr.validateState(fresh)
+    expect(result.valid).toBe(true)
+  })
+
+  it('a captured nonce from before the eviction window is rejected, but fresh nonces still work', async () => {
+    // Realistic end-to-end: attacker captured a nonce in the past, server's
+    // nonce map later fills up and evicts a window that covers that nonce,
+    // then the attacker replays. The captured nonce must be rejected by the
+    // high-water mark, while fresh nonces signed *after* the eviction still
+    // validate normally.
+    //
+    // The eviction window is driven by the oldest nonces in the map, so we
+    // seed them in the comfortable past. The captured nonce must lie inside
+    // that window. We also wait a millisecond before signing the fresh nonce
+    // so that Date.now() advances past the high-water mark.
+
+    const MAX = (StateSignatureManager as any).MAX_NONCES as number
+    const pastBase = Date.now() - 60_000 // 60s ago
+
+    // Craft a "captured" nonce whose embedded ts falls inside the eviction
+    // window. We sign it by mutating an already-valid nonce's timestamp and
+    // recomputing the outer signature via signState — but the simplest way
+    // is to sign fresh and manually rewrite the nonce+signature.
+    const raw = mgr.signState('c', { a: 1 }, 1)
+    // Replace the nonce timestamp so it looks like it was minted in the past.
+    // We need to regenerate the HMAC with the manager's secret. The secret
+    // is private, but we can piggyback on generateNonce via reflection.
+    const fakePastTs = pastBase + 2 // inside the eviction window
+    const fakeNonce = ((mgr as any).generateNonceAt
+      ? (mgr as any).generateNonceAt(fakePastTs)
+      : null)
+    // Fall back: sign a brand-new state but with the nonce monkey-patched.
+    // Since the outer signature binds the nonce, we can't just swap it. So
+    // instead, we seed the eviction window at a time that *contains* the
+    // raw nonce's real ts.
+    void fakeNonce
+
+    const capturedTs = Number(raw.nonce!.split(':')[0])
+
+    // Clear the map, then seed 10% below capturedTs and 90% above, so
+    // capturedTs sits inside the eviction window (oldest 10%).
+    ;(mgr as any).usedNonces.clear()
+    // Base is capturedTs - toRemove, so the window [base .. base+toRemove-1]
+    // straddles capturedTs as its last entry (= capturedTs - 1). Bump by 2
+    // extra so the window clearly includes capturedTs itself.
+    const toRemove = Math.floor((MAX + 1) * 0.1)
+    const seedBase = capturedTs - toRemove + 2
+    seedSyntheticNonces(MAX + 1, seedBase)
+    ;(mgr as any).evictOldNoncesIfNeeded()
+
+    const mark = (mgr as any).evictionHighWaterMark as number
+    expect(mark).toBeGreaterThanOrEqual(capturedTs)
+
+    // Attacker replay: the captured nonce's embedded ts is at or below the mark.
+    const replay = mgr.validateState(raw)
+    expect(replay.valid).toBe(false)
+    expect(replay.error).toMatch(/predates replay-protection window/)
+
+    // Wait until Date.now() advances past the high-water mark so a freshly
+    // signed nonce is strictly newer. The mark is ≈ capturedTs which is ≈
+    // Date.now() at the time of sign; 5ms is enough to step past it.
+    await new Promise((r) => setTimeout(r, 5))
+
+    const fresh = mgr.signState('c', { b: 2 }, 1)
+    const freshTs = Number(fresh.nonce!.split(':')[0])
+    expect(freshTs).toBeGreaterThan(mark)
+    expect(mgr.validateState(fresh).valid).toBe(true)
+  })
+})

--- a/packages/core/src/auth/LiveAuthContext.ts
+++ b/packages/core/src/auth/LiveAuthContext.ts
@@ -18,9 +18,22 @@ export class AuthenticatedContext implements LiveAuthContext {
   get user(): LiveAuthSession { return this.session }
 
   constructor(session: LiveAuthSession, token?: string) {
-    this.session = session
+    // Defensive deep-freeze of the session so handlers (or bugs in handlers)
+    // cannot mutate `this.$auth.session.roles` / `.permissions` / `.id` and
+    // alter subsequent authorize() decisions within the same request chain.
+    // Fixes #4 (part 2). We copy the arrays first so we do not accidentally
+    // freeze the caller's own objects — this keeps the freeze local to the
+    // auth context and lets the caller keep its own mutable sources of truth.
+    const frozenSession: LiveAuthSession = {
+      ...session,
+      roles: session.roles ? Object.freeze([...session.roles]) as readonly string[] as string[] : session.roles,
+      permissions: session.permissions ? Object.freeze([...session.permissions]) as readonly string[] as string[] : session.permissions,
+    }
+    this.session = Object.freeze(frozenSession)
     this.token = token
     this.authenticatedAt = Date.now()
+    // Freeze the context instance itself to prevent property replacement.
+    Object.freeze(this)
   }
 
   hasRole(role: string): boolean {
@@ -71,5 +84,5 @@ export class AnonymousContext implements LiveAuthContext {
   hasAnyPermission(): boolean { return false }
 }
 
-/** Singleton for anonymous contexts */
-export const ANONYMOUS_CONTEXT = new AnonymousContext()
+/** Singleton for anonymous contexts — frozen so callers cannot mutate the shared instance. */
+export const ANONYMOUS_CONTEXT = Object.freeze(new AnonymousContext())

--- a/packages/core/src/auth/LiveAuthManager.ts
+++ b/packages/core/src/auth/LiveAuthManager.ts
@@ -12,6 +12,27 @@ import type {
 } from './types'
 import { ANONYMOUS_CONTEXT } from './LiveAuthContext'
 
+/**
+ * Coerce the result of a user-provided `authorize()` callback into a strict
+ * LiveAuthResult. We accept only booleans or objects with an explicit
+ * `allowed: true` — anything else (primitive, null, undefined, object without
+ * `allowed === true`) is treated as deny. Fixes #4 (part 3): prevents
+ * accidental allow via a stray non-boolean return type, and prevents
+ * consumers downstream from seeing `result.allowed === undefined`.
+ */
+function coerceAuthResult(result: unknown, denyReason: string): LiveAuthResult {
+  if (result === true) return { allowed: true }
+  if (result === false) return { allowed: false, reason: denyReason }
+  if (typeof result === 'object' && result !== null && (result as LiveAuthResult).allowed === true) {
+    return result as LiveAuthResult
+  }
+  if (typeof result === 'object' && result !== null && (result as LiveAuthResult).allowed === false) {
+    return result as LiveAuthResult
+  }
+  // Unknown shape — fail closed.
+  return { allowed: false, reason: denyReason }
+}
+
 export class LiveAuthManager {
   private providers = new Map<string, LiveAuthProvider>()
   private defaultProviderName?: string
@@ -167,12 +188,9 @@ export class LiveAuthManager {
     // Custom authorize function (runs after declarative checks pass)
     if (authConfig.authorize) {
       try {
-        const result = await authConfig.authorize(authContext)
-        if (typeof result === 'boolean') {
-          if (!result) return { allowed: false, reason: 'Denied by custom authorize' }
-        } else {
-          if (!result.allowed) return result
-        }
+        const raw = await authConfig.authorize(authContext)
+        const coerced = coerceAuthResult(raw, 'Denied by custom authorize')
+        if (!coerced.allowed) return coerced
       } catch (error: any) {
         return { allowed: false, reason: `Authorization error: ${error.message}` }
       }
@@ -218,12 +236,9 @@ export class LiveAuthManager {
     // Custom authorize function (runs after declarative checks pass)
     if (actionAuth.authorize) {
       try {
-        const result = await actionAuth.authorize(authContext, payload)
-        if (typeof result === 'boolean') {
-          if (!result) return { allowed: false, reason: `Action '${action}' denied by custom authorize` }
-        } else {
-          if (!result.allowed) return result
-        }
+        const raw = await actionAuth.authorize(authContext, payload)
+        const coerced = coerceAuthResult(raw, `Action '${action}' denied by custom authorize`)
+        if (!coerced.allowed) return coerced
       } catch (error: any) {
         return { allowed: false, reason: `Action '${action}' authorization error: ${error.message}` }
       }

--- a/packages/core/src/security/StateSignature.ts
+++ b/packages/core/src/security/StateSignature.ts
@@ -60,6 +60,19 @@ export class StateSignatureManager {
   private nonceCleanupTimer?: ReturnType<typeof setInterval>
   /** Maximum number of nonces to keep in the replay detection map. */
   private static readonly MAX_NONCES = 100_000
+  /**
+   * Replay protection high-water mark (fixes #4).
+   *
+   * When the nonce map is capped and we evict entries to make room, the evicted
+   * nonces may still be within their TTL — a naive eviction would open a replay
+   * window. Instead, we track the newest timestamp we ever evicted and reject any
+   * subsequent nonce whose own `ts` (embedded in the nonce itself) is at or
+   * before that mark. This makes eviction fail-closed: once we drop a nonce, we
+   * treat the entire window up to that point as "already seen".
+   *
+   * Starts at 0; only advances forward. Reset by shutdown/new instance.
+   */
+  private evictionHighWaterMark = 0
 
   constructor(config: StateSignatureConfig = {}) {
     const defaultSecret = typeof process !== 'undefined'
@@ -129,6 +142,13 @@ export class StateSignatureManager {
     if (age < -30000) {
       // Nonce from the future (>30s clock skew) — reject
       return { valid: false, error: 'Nonce timestamp in the future' }
+    }
+
+    // Fail-closed replay protection: if the nonce predates the eviction
+    // high-water mark, we can no longer prove it's unused — reject it.
+    // See `evictionHighWaterMark` for rationale.
+    if (timestamp <= this.evictionHighWaterMark) {
+      return { valid: false, error: 'Nonce predates replay-protection window' }
     }
 
     // Verify HMAC — try current key first, then previous keys (rotation)
@@ -348,15 +368,44 @@ export class StateSignatureManager {
     }
   }
 
-  /** Evict oldest 10% of nonces when the map exceeds MAX_NONCES to prevent unbounded memory growth. */
+  /**
+   * Evict oldest 10% of nonces when the map exceeds MAX_NONCES to prevent
+   * unbounded memory growth.
+   *
+   * Because a raw eviction would open a replay window for evicted nonces that
+   * are still within their TTL, we also advance `evictionHighWaterMark` to the
+   * newest *embedded* timestamp we drop. Any subsequent nonce whose embedded
+   * timestamp is at or before that mark is rejected by `validateNonce` — the
+   * entire evicted window is treated as "already seen". Fixes #4.
+   *
+   * Note: `usedNonces` is keyed by insertion order (oldest-first), but the
+   * value stored in the Map is the wall-clock time the nonce was first seen
+   * — NOT the embedded timestamp. We parse the embedded ts from each evicted
+   * key so the high-water mark is comparable to what `validateNonce` checks.
+   */
   private evictOldNoncesIfNeeded(): void {
     if (this.usedNonces.size <= StateSignatureManager.MAX_NONCES) return
     const toRemove = Math.floor(this.usedNonces.size * 0.1)
     let removed = 0
+    let newestEvictedTs = this.evictionHighWaterMark
     for (const [key] of this.usedNonces) {
       if (removed >= toRemove) break
+      // Extract embedded timestamp from `ts:rand:mac` nonce format.
+      const colonIdx = key.indexOf(':')
+      if (colonIdx > 0) {
+        const embeddedTs = Number(key.slice(0, colonIdx))
+        if (!isNaN(embeddedTs) && embeddedTs > newestEvictedTs) {
+          newestEvictedTs = embeddedTs
+        }
+      }
       this.usedNonces.delete(key)
       removed++
+    }
+    // Fail-closed: advance the high-water mark so any future nonce from the
+    // evicted window is rejected as a potential replay.
+    if (newestEvictedTs > this.evictionHighWaterMark) {
+      this.evictionHighWaterMark = newestEvictedTs
+      liveWarn('state', null, `Nonce map capped at ${StateSignatureManager.MAX_NONCES}; evicted ${removed} entries. Replay-protection window advanced to ts=${newestEvictedTs}. Clients with in-flight state older than this will be rejected.`)
     }
   }
 


### PR DESCRIPTION
Closes #4.

## Summary

Three independent security hardenings, all surfaced by the preventive bug-hunt suite after we fixed #2 and #3. Packaged together because they share the same blast radius (auth/authz) and are covered by the same reproducer.

### 1. Nonce eviction no longer opens a replay window (the critical one)

`StateSignature` capped `usedNonces` at 100k and evicted the oldest 10% on overflow. The eviction removed legitimate nonces that were **still within their TTL**, so an attacker holding a captured `SignedState` could replay it after forcing the map to fill. Confirmed by two independent reproducers during the bug hunt.

Fix: track an `evictionHighWaterMark` set to the newest *embedded* timestamp we ever drop. `validateNonce` now rejects any nonce whose embedded ts is at or below that mark — the entire evicted window is treated as "already seen". A `liveWarn` is logged on every eviction so operators notice churn.

### 2. `$auth.session` is deep-frozen

`AuthenticatedContext` stored the caller's session by reference, so any handler bug that mutated `this.\$auth.session.roles.push('admin')` silently changed every subsequent `authorize()` decision in the same process. The constructor now copies the roles/permissions arrays, freezes them, freezes the session, and freezes the context instance. `ANONYMOUS_CONTEXT` (the shared singleton) is also frozen.

### 3. `authorize()` return value is strictly coerced

A user-supplied `authorize()` that returned a primitive (`'true'`, `0`, `null`, `undefined`, or `{ foo: 'bar' }`) used to land in `result.allowed === undefined`. Callers using `if (!result.allowed)` were fail-closed by accident, but strict consumers checking `result.allowed === false` would miss the deny. New `coerceAuthResult` helper accepts only `true`, `false`, or objects with explicit `allowed: true/false`; everything else becomes a deny.

## Files changed

- `packages/core/src/security/StateSignature.ts` — high-water mark logic
- `packages/core/src/auth/LiveAuthContext.ts` — defensive freeze
- `packages/core/src/auth/LiveAuthManager.ts` — `coerceAuthResult` helper + call sites

## Regression tests added

- `packages/core/src/__tests__/security/StateSignature.replay-eviction.test.ts` (5 tests)
- `packages/core/src/__tests__/auth/session-freeze.test.ts` (8 tests)
- `packages/core/src/__tests__/auth/authorize-strict-return.test.ts` (13 tests)

One existing test (`auth-manager-authorize.test.ts`) was updated: it expected `ctx.session === inputSession` (reference identity), which is no longer true now that the constructor defensively copies. Changed to `.toEqual` with a comment.

## Test plan

- [x] `bunx tsc -p packages/core/tsconfig.json --noEmit` clean
- [x] 26/26 new tests passing
- [x] Full suite: **539/539** passing on core/react/client
- [x] `bun run build:core` clean

## Notes for reviewers

- The eviction high-water mark is monotonic (only advances) and resets only on new manager instance. This is deliberate — once we've "forgotten" nonces from some window, we cannot safely accept anything from that window ever again within the current process.
- Freezing `AuthenticatedContext` means reassigning `ctx.session` now throws in strict mode. If any caller was relying on post-construction mutation of the context, this is a breaking change — but that behavior was already unsafe and is what we want to prevent.
- `coerceAuthResult` preserves the existing shape for well-typed callers (boolean or `LiveAuthResult` object) and only changes behavior for out-of-contract returns, which were previously fail-closed by accident via `undefined` falsy-check. No safe code should break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)