### PR TITLE
fix(rooms): isolate LiveRoom lifecycle hook errors, fix onCreate order and onDestroy await (fixes #5)

### DIFF
--- a/packages/core/src/__tests__/rooms/LiveRoomManager.lifecycle-hooks.test.ts
+++ b/packages/core/src/__tests__/rooms/LiveRoomManager.lifecycle-hooks.test.ts
@@ -1,0 +1,469 @@
+// Regression tests for issue #5: LiveRoom lifecycle hook safety.
+//
+// Before the fix, hooks declared on a LiveRoom subclass (onCreate, onJoin,
+// onEvent, onLeave, onDestroy) were invoked by LiveRoomManager without any
+// isolation — synchronous throws propagated through joinRoom/emitToRoom/
+// cleanupComponent, async rejections became unhandledRejections,
+// Promise<false> returned from onDestroy was ignored, and onCreate fired
+// AFTER the first onJoin, contradicting the documented contract.
+//
+// This suite is the permanent home of the bug-hunt reproducer (originally
+// in __tests__/bug-hunt/lifecycle-hooks.test.ts). Each describe block
+// maps to one of the hypotheses that originally flagged the bug; with
+// the fix in place they all pass.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { LiveRoomManager } from '../../rooms/LiveRoomManager'
+import { LiveRoom } from '../../rooms/LiveRoom'
+import { RoomRegistry } from '../../rooms/RoomRegistry'
+import { RoomEventBus } from '../../rooms/RoomEventBus'
+import { LiveComponent } from '../../component/LiveComponent'
+import type { GenericWebSocket, LiveWSData } from '../../transport/types'
+import { ANONYMOUS_CONTEXT } from '../../auth/LiveAuthContext'
+
+// Silence the batcher / logger side-effects
+vi.mock('../../transport/WsSendBatcher', () => ({
+  queueWsMessage: vi.fn(),
+  queuePreSerialized: vi.fn(),
+  sendImmediate: vi.fn(),
+  sendBinaryImmediate: vi.fn(),
+}))
+
+vi.mock('../../debug/LiveLogger', () => ({
+  liveLog: vi.fn(),
+  liveWarn: vi.fn(),
+  registerComponentLogging: vi.fn(),
+  unregisterComponentLogging: vi.fn(),
+}))
+
+// ---------- helpers ----------
+
+function createMockWS(): GenericWebSocket & { _sent: any[] } {
+  const sent: any[] = []
+  const data: LiveWSData = {
+    connectionId: `ws-${Math.random().toString(36).slice(2, 10)}`,
+    components: new Map(),
+    subscriptions: new Set(),
+    connectedAt: new Date(),
+    userId: undefined,
+    authContext: ANONYMOUS_CONTEXT,
+  }
+  return {
+    send: (m: any) => sent.push(m),
+    close: () => {},
+    data,
+    remoteAddress: '127.0.0.1',
+    readyState: 1 as const,
+    _sent: sent,
+  } as any
+}
+
+function makeManager() {
+  const bus = new RoomEventBus()
+  const mgr = new LiveRoomManager(bus)
+  const registry = new RoomRegistry()
+  mgr.roomRegistry = registry
+  return { mgr, bus, registry }
+}
+
+// silence console.error noise from expected errors
+let errSpy: ReturnType<typeof vi.spyOn>
+beforeEach(() => {
+  errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+afterEach(() => {
+  errSpy.mockRestore()
+  vi.clearAllMocks()
+})
+
+// ===================================================================
+// H1: synchronous throw in onCreate must not crash joinRoom
+// ===================================================================
+describe('onCreate — synchronous throw is isolated', () => {
+  it('onCreate throwing is caught; joinRoom resolves with a rejection', async () => {
+    const { mgr, registry } = makeManager()
+
+    class BadCreate extends LiveRoom<{ ready: boolean }> {
+      static roomName = 'h1'
+      static defaultState = { ready: false }
+      onCreate() {
+        throw new Error('boom from onCreate')
+      }
+    }
+    registry.register(BadCreate as any)
+
+    const ws = createMockWS()
+    // The framework must not let the hook's error escape.
+    const result = await mgr.joinRoom('c-1', 'h1:lobby', ws)
+    // Room initialization failed → join is rejected and the room is torn down.
+    expect((result as any).rejected).toBe(true)
+    expect(mgr.getStats().totalRooms).toBe(0)
+  })
+})
+
+// ===================================================================
+// H2: async onCreate rejection does not become unhandledRejection
+// ===================================================================
+describe('onCreate — async rejection is caught', () => {
+  it('async onCreate rejection is awaited and handled without unhandledRejection', async () => {
+    const { mgr, registry } = makeManager()
+    const rejections: unknown[] = []
+    const handler = (reason: unknown) => rejections.push(reason)
+    process.on('unhandledRejection', handler)
+
+    class AsyncBad extends LiveRoom<{ x: number }> {
+      static roomName = 'h2'
+      static defaultState = { x: 0 }
+      async onCreate() {
+        await Promise.resolve()
+        throw new Error('async create boom')
+      }
+    }
+    registry.register(AsyncBad as any)
+
+    const ws = createMockWS()
+    const result = await mgr.joinRoom('c-1', 'h2:lobby', ws)
+
+    // let any rejected microtask settle
+    await new Promise((r) => setTimeout(r, 10))
+    process.off('unhandledRejection', handler)
+
+    expect(rejections).toHaveLength(0)
+    expect((result as any).rejected).toBe(true)
+  })
+})
+
+// ===================================================================
+// H3: synchronous throw in onEvent must not break emitToRoom
+// ===================================================================
+describe('onEvent — synchronous throw is isolated', () => {
+  it('onEvent throwing does not prevent the broadcast from running', async () => {
+    const { mgr, registry } = makeManager()
+
+    class BadEvent extends LiveRoom<{ n: number }> {
+      static roomName = 'h3'
+      static defaultState = { n: 0 }
+      onEvent() {
+        throw new Error('boom from onEvent')
+      }
+    }
+    registry.register(BadEvent as any)
+
+    const ws1 = createMockWS()
+    const ws2 = createMockWS()
+    await mgr.joinRoom('c-1', 'h3:lobby', ws1)
+    await mgr.joinRoom('c-2', 'h3:lobby', ws2)
+
+    expect(() => mgr.emitToRoom('h3:lobby', 'ping', { a: 1 })).not.toThrow()
+  })
+
+  it('async onEvent rejection is caught and does not surface as unhandledRejection', async () => {
+    const { mgr, registry } = makeManager()
+    const rejections: unknown[] = []
+    const handler = (reason: unknown) => rejections.push(reason)
+    process.on('unhandledRejection', handler)
+
+    class AsyncBadEvent extends LiveRoom<{ n: number }> {
+      static roomName = 'h3b'
+      static defaultState = { n: 0 }
+      async onEvent() {
+        await Promise.resolve()
+        throw new Error('async event boom')
+      }
+    }
+    registry.register(AsyncBadEvent as any)
+
+    const ws = createMockWS()
+    await mgr.joinRoom('c-1', 'h3b:lobby', ws)
+    expect(() => mgr.emitToRoom('h3b:lobby', 'ping', {})).not.toThrow()
+
+    await new Promise((r) => setTimeout(r, 10))
+    process.off('unhandledRejection', handler)
+
+    expect(rejections).toHaveLength(0)
+  })
+})
+
+// ===================================================================
+// H4: async onEvent is observer-only (documented contract)
+// ===================================================================
+describe('onEvent — observer contract', () => {
+  it('async onEvent runs fire-and-forget after the synchronous broadcast path', async () => {
+    const { mgr, registry } = makeManager()
+    const callOrder: string[] = []
+
+    class AsyncHook extends LiveRoom<{ n: number }> {
+      static roomName = 'h4'
+      static defaultState = { n: 0 }
+      async onEvent(event: string) {
+        callOrder.push(`start:${event}`)
+        await Promise.resolve()
+        callOrder.push(`end:${event}`)
+      }
+    }
+    registry.register(AsyncHook as any)
+
+    const ws = createMockWS()
+    await mgr.joinRoom('c-1', 'h4:lobby', ws)
+
+    mgr.emitToRoom('h4:lobby', 'e1', {})
+    mgr.emitToRoom('h4:lobby', 'e2', {})
+
+    await new Promise((r) => setTimeout(r, 10))
+
+    // Contract: onEvent is observer-only. Both starts are called synchronously
+    // before either end because the framework does not await the hook — the
+    // broadcast path must not be gated on user code. This documents the
+    // behaviour that #5 H4 originally flagged; the fix logs async rejections
+    // but keeps the fire-and-forget semantics intentional.
+    expect(callOrder.slice(0, 2)).toEqual(['start:e1', 'start:e2'])
+    expect(callOrder.slice(2).sort()).toEqual(['end:e1', 'end:e2'])
+  })
+})
+
+// ===================================================================
+// H5: Promise<false> from onDestroy must cancel destruction
+// ===================================================================
+describe('onDestroy — Promise<false> cancels destruction', () => {
+  it('async onDestroy resolving to false keeps the room alive', async () => {
+    vi.useFakeTimers()
+    const { mgr, registry } = makeManager()
+
+    class StickyRoom extends LiveRoom<{ keep: boolean }> {
+      static roomName = 'h5'
+      static defaultState = { keep: true }
+      async onDestroy() {
+        await Promise.resolve()
+        return false as const
+      }
+    }
+    registry.register(StickyRoom as any)
+
+    const ws = createMockWS()
+    await mgr.joinRoom('c-1', 'h5:main', ws)
+    await mgr.leaveRoom('c-1', 'h5:main')
+
+    // Advance past the 5 minute cleanup timer
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1000)
+
+    vi.useRealTimers()
+
+    // Room should still exist because onDestroy returned Promise<false>
+    expect(mgr.getStats().totalRooms).toBe(1)
+  })
+
+  it('async onDestroy resolving to undefined destroys the room', async () => {
+    vi.useFakeTimers()
+    const { mgr, registry } = makeManager()
+
+    class NormalRoom extends LiveRoom {
+      static roomName = 'h5b'
+      static defaultState = {}
+      async onDestroy() {
+        await Promise.resolve()
+      }
+    }
+    registry.register(NormalRoom as any)
+
+    const ws = createMockWS()
+    await mgr.joinRoom('c-1', 'h5b:main', ws)
+    await mgr.leaveRoom('c-1', 'h5b:main')
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1000)
+
+    vi.useRealTimers()
+
+    expect(mgr.getStats().totalRooms).toBe(0)
+  })
+
+  it('synchronous throw in onDestroy destroys the room and logs', async () => {
+    vi.useFakeTimers()
+    const { mgr, registry } = makeManager()
+
+    class BrokenDestroy extends LiveRoom {
+      static roomName = 'h5c'
+      static defaultState = {}
+      onDestroy() {
+        throw new Error('destroy boom')
+      }
+    }
+    registry.register(BrokenDestroy as any)
+
+    const ws = createMockWS()
+    await mgr.joinRoom('c-1', 'h5c:main', ws)
+    await mgr.leaveRoom('c-1', 'h5c:main')
+
+    // No unhandled rejection, and the room is destroyed despite the throw.
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1000)
+
+    vi.useRealTimers()
+
+    expect(mgr.getStats().totalRooms).toBe(0)
+  })
+})
+
+// ===================================================================
+// H6: cleanupComponent — onLeave throws must not leak remaining rooms
+// ===================================================================
+describe('cleanupComponent — onLeave throws are isolated per room', () => {
+  it('a single onLeave error does not prevent other rooms from being cleaned', async () => {
+    const { mgr, registry } = makeManager()
+
+    class BadLeaveA extends LiveRoom {
+      static roomName = 'h6a'
+      static defaultState = {}
+      onLeave() {
+        throw new Error('boom in a')
+      }
+    }
+    class GoodB extends LiveRoom {
+      static roomName = 'h6b'
+      static defaultState = {}
+    }
+    registry.register(BadLeaveA as any)
+    registry.register(GoodB as any)
+
+    const ws = createMockWS()
+    await mgr.joinRoom('c-1', 'h6a:x', ws)
+    await mgr.joinRoom('c-1', 'h6b:y', ws)
+
+    // Cleanup must not throw AND must remove comp from both rooms
+    await expect(mgr.cleanupComponent('c-1')).resolves.toBeUndefined()
+    expect(mgr.isInRoom('c-1', 'h6a:x')).toBe(false)
+    expect(mgr.isInRoom('c-1', 'h6b:y')).toBe(false)
+  })
+
+  it('single-room leaveRoom() also isolates onLeave throws', async () => {
+    const { mgr, registry } = makeManager()
+
+    class BadLeave extends LiveRoom {
+      static roomName = 'h6c'
+      static defaultState = {}
+      onLeave() {
+        throw new Error('boom leave')
+      }
+    }
+    registry.register(BadLeave as any)
+
+    const ws = createMockWS()
+    await mgr.joinRoom('c-1', 'h6c:main', ws)
+
+    await expect(mgr.leaveRoom('c-1', 'h6c:main')).resolves.toBeUndefined()
+    expect(mgr.isInRoom('c-1', 'h6c:main')).toBe(false)
+  })
+})
+
+// ===================================================================
+// H7: onCreate must fire BEFORE the first onJoin
+// ===================================================================
+describe('ordering — onCreate runs before the first onJoin', () => {
+  it('first onJoin observes state already seeded by onCreate', async () => {
+    const { mgr, registry } = makeManager()
+    const observed: { hook: string; seeded: boolean }[] = []
+
+    class SeededRoom extends LiveRoom<{ seeded: boolean }> {
+      static roomName = 'h7'
+      static defaultState = { seeded: false }
+      onCreate() {
+        observed.push({ hook: 'onCreate', seeded: (this.state as any).seeded })
+        ;(this.state as any).seeded = true
+      }
+      onJoin() {
+        observed.push({ hook: 'onJoin', seeded: (this.state as any).seeded })
+      }
+    }
+    registry.register(SeededRoom as any)
+
+    const ws = createMockWS()
+    await mgr.joinRoom('c-1', 'h7:room', ws)
+
+    // Contract: onCreate runs once, before the first onJoin, and the first
+    // join sees the already-seeded state.
+    const createIdx = observed.findIndex((e) => e.hook === 'onCreate')
+    const joinIdx = observed.findIndex((e) => e.hook === 'onJoin')
+    expect(createIdx).toBeGreaterThanOrEqual(0)
+    expect(joinIdx).toBeGreaterThanOrEqual(0)
+    expect(createIdx).toBeLessThan(joinIdx)
+    expect(observed[joinIdx].seeded).toBe(true)
+  })
+
+  it('onCreate only fires for the first member, not subsequent joins', async () => {
+    const { mgr, registry } = makeManager()
+    const createCalls: number[] = []
+
+    class OnceRoom extends LiveRoom {
+      static roomName = 'h7b'
+      static defaultState = {}
+      onCreate() {
+        createCalls.push(Date.now())
+      }
+    }
+    registry.register(OnceRoom as any)
+
+    const ws1 = createMockWS()
+    const ws2 = createMockWS()
+    await mgr.joinRoom('c-1', 'h7b:room', ws1)
+    await mgr.joinRoom('c-2', 'h7b:room', ws2)
+
+    expect(createCalls).toHaveLength(1)
+  })
+})
+
+// ===================================================================
+// H8: cascading setState inside onStateChange — intentional guard
+// ===================================================================
+describe.skip('onStateChange reentrancy (intentional guard, documented)', () => {
+  // The _inStateChange guard in ComponentStateManager is intentional: it
+  // prevents infinite cascades when onStateChange triggers another setState.
+  // The cascade is still applied to state and emitted as a STATE_DELTA to
+  // the client, but the hook is NOT re-entered. This is a known tradeoff,
+  // not a bug, so the test is skipped — kept here for documentation.
+  it('cascading setState is visible on the client but skips the hook', async () => {
+    const ws = createMockWS()
+    const observed: any[] = []
+
+    class Cascader extends LiveComponent<{ a: number; b: number }> {
+      static componentName = 'Cascader'
+      static defaultState = { a: 0, b: 0 }
+      protected onStateChange(changes: Partial<{ a: number; b: number }>): void {
+        observed.push({ ...changes })
+        if ('a' in changes && (this.state as any).b === 0) {
+          this.setState({ b: (changes.a ?? 0) * 2 })
+        }
+      }
+    }
+
+    const c = new Cascader({}, ws as any)
+    c.setState({ a: 5 })
+
+    const sawBUpdate = observed.some((o) => 'b' in o)
+    expect(sawBUpdate).toBe(true)
+  })
+})
+
+// ===================================================================
+// H9: LiveComponent onMount throws must leave the component usable
+// ===================================================================
+describe('LiveComponent onMount — throw leaves component usable', () => {
+  it('setState after a failed onMount still propagates a delta', async () => {
+    const ws = createMockWS()
+
+    class BadMount extends LiveComponent<{ v: number }> {
+      static componentName = 'BadMount'
+      static defaultState = { v: 0 }
+      protected async onMount() {
+        throw new Error('mount failed')
+      }
+    }
+
+    const c = new BadMount({}, ws as any)
+    try {
+      await (c as any).onMount()
+    } catch {
+      /* ignore */
+    }
+
+    expect(() => c.setState({ v: 42 })).not.toThrow()
+    expect((c.state as any).v).toBe(42)
+  })
+})

--- a/packages/core/src/rooms/LiveRoomManager.ts
+++ b/packages/core/src/rooms/LiveRoomManager.ts
@@ -5,7 +5,7 @@
 import type { RoomEventBus } from './RoomEventBus'
 import type { GenericWebSocket } from '../transport/types'
 import { queueWsMessage, queuePreSerialized, sendBinaryImmediate } from '../transport/WsSendBatcher'
-import { liveLog } from '../debug/LiveLogger'
+import { liveLog, liveWarn } from '../debug/LiveLogger'
 import { MAX_ROOM_STATE_SIZE, ROOM_NAME_REGEX } from '../protocol/constants'
 import type { IRoomPubSubAdapter } from './adapters'
 import { computeDeepDiff, deepAssign } from '../utils/deepDiff'
@@ -150,27 +150,50 @@ export class LiveRoomManager {
       }
     }
 
-    // Call onJoin lifecycle hook for LiveRoom-backed rooms
+    // Call onCreate BEFORE the first onJoin so the first member sees
+    // any state the room seeds during creation. Fixes #5 H7: the old order
+    // ran onJoin first and contradicted LiveRoom.ts:148 which documents
+    // onCreate as "called once when the room is first created (first
+    // member joins)". We isolate throws/rejections so a broken onCreate
+    // cannot leak an exception out of joinRoom — the room is torn down
+    // and the join is rejected cleanly.
+    if (isNewRoom && room.instance) {
+      try {
+        await room.instance.onCreate()
+      } catch (err: any) {
+        liveWarn('rooms', componentId, `Room '${roomId}' onCreate threw: ${err?.message || err}`)
+        this.rooms.delete(roomId)
+        return { rejected: true, reason: 'Room initialization failed' }
+      }
+    }
+
+    // Call onJoin lifecycle hook for LiveRoom-backed rooms. Isolated so a
+    // broken onJoin cannot leak an exception out of joinRoom either — we
+    // treat throws as an implicit rejection (same path as result === false).
     if (room.instance) {
-      const result = await room.instance.onJoin({
-        componentId,
-        userId: joinContext?.userId,
-        payload: joinContext?.payload,
-      })
+      let joinResult: void | false
+      try {
+        joinResult = await room.instance.onJoin({
+          componentId,
+          userId: joinContext?.userId,
+          payload: joinContext?.payload,
+        })
+      } catch (err: any) {
+        liveWarn('rooms', componentId, `Room '${roomId}' onJoin threw: ${err?.message || err}`)
+        if (isNewRoom) {
+          this.rooms.delete(roomId)
+        }
+        return { rejected: true, reason: 'Join rejected by room' }
+      }
 
       // Handle rejection (sync or async)
-      if (result === false) {
+      if (joinResult === false) {
         // If this was a new room and join was rejected, clean up
         if (isNewRoom) {
           this.rooms.delete(roomId)
         }
         return { rejected: true, reason: 'Join rejected by room' }
       }
-    }
-
-    // Call onCreate for new LiveRoom instances (after onJoin succeeds)
-    if (isNewRoom && room.instance) {
-      room.instance.onCreate()
     }
 
     // Add member
@@ -219,12 +242,18 @@ export class LiveRoomManager {
     const room = this.rooms.get(roomId)
     if (!room) return
 
-    // Call onLeave lifecycle hook for LiveRoom-backed rooms (await async cleanup)
+    // Call onLeave lifecycle hook for LiveRoom-backed rooms (await async cleanup).
+    // Fixes #5 H6: isolate throws so a broken hook cannot prevent member removal
+    // and the downstream broadcasts below.
     if (room.instance) {
-      await room.instance.onLeave({
-        componentId,
-        reason: leaveReason,
-      })
+      try {
+        await room.instance.onLeave({
+          componentId,
+          reason: leaveReason,
+        })
+      } catch (err: any) {
+        liveWarn('rooms', componentId, `Room '${roomId}' onLeave threw: ${err?.message || err}. Continuing with cleanup.`)
+      }
     }
 
     room.members.delete(componentId)
@@ -255,19 +284,41 @@ export class LiveRoomManager {
 
     // Cleanup empty room after delay
     if (memberCount === 0) {
-      setTimeout(() => {
-        const currentRoom = this.rooms.get(roomId)
-        if (currentRoom && currentRoom.members.size === 0) {
-          // Call onDestroy for LiveRoom-backed rooms
-          if (currentRoom.instance) {
-            const result = currentRoom.instance.onDestroy()
-            if (result === false) return // Room wants to stay alive
-          }
-          this.rooms.delete(roomId)
-          liveLog('rooms', null, `Room '${roomId}' destroyed (empty)`)
-        }
-      }, 5 * 60 * 1000)
+      this.scheduleEmptyRoomDestruction(roomId)
     }
+  }
+
+  /**
+   * Schedule destruction of a now-empty room after a 5-minute grace period.
+   * When the timer fires, the room is only destroyed if it is still empty
+   * AND onDestroy did not cancel (returning `false` or `Promise<false>`).
+   *
+   * Fixes #5 H5: previously the code called `currentRoom.instance.onDestroy()`
+   * without awaiting and compared the returned Promise to `false` — which is
+   * always `false` for a Promise, so `async onDestroy() { return false }`
+   * (documented in LiveRoom.ts:155 as a supported cancel signal) was silently
+   * ignored and the room was always destroyed.
+   */
+  private scheduleEmptyRoomDestruction(roomId: string): void {
+    setTimeout(async () => {
+      const currentRoom = this.rooms.get(roomId)
+      if (!currentRoom || currentRoom.members.size !== 0) return
+
+      // Call onDestroy for LiveRoom-backed rooms. Await the result so
+      // Promise<false> is properly honoured, and isolate throws so a
+      // broken onDestroy cannot leave the room in a half-destroyed state.
+      if (currentRoom.instance) {
+        try {
+          const result = await currentRoom.instance.onDestroy()
+          if (result === false) return // Room wants to stay alive
+        } catch (err: any) {
+          liveWarn('rooms', null, `Room '${roomId}' onDestroy threw: ${err?.message || err}. Destroying anyway.`)
+        }
+      }
+
+      this.rooms.delete(roomId)
+      liveLog('rooms', null, `Room '${roomId}' destroyed (empty)`)
+    }, 5 * 60 * 1000)
   }
 
   /**
@@ -287,12 +338,20 @@ export class LiveRoomManager {
       const room = this.rooms.get(roomId)
       if (!room) continue
 
-      // Call onLeave lifecycle hook for LiveRoom-backed rooms (await async cleanup)
+      // Call onLeave lifecycle hook for LiveRoom-backed rooms (await async cleanup).
+      // Fixes #5 H6: a single broken onLeave must not interrupt the loop —
+      // otherwise the component would remain a member of every subsequent
+      // room and componentRooms.delete() at the end of this method would
+      // never execute, leaking memory and missing leave notifications.
       if (room.instance) {
-        await room.instance.onLeave({
-          componentId,
-          reason: 'disconnect',
-        })
+        try {
+          await room.instance.onLeave({
+            componentId,
+            reason: 'disconnect',
+          })
+        } catch (err: any) {
+          liveWarn('rooms', componentId, `Room '${roomId}' onLeave threw during cleanup: ${err?.message || err}. Continuing with remaining rooms.`)
+        }
       }
 
       room.members.delete(componentId)
@@ -303,19 +362,8 @@ export class LiveRoomManager {
       if (memberCount > 0) {
         notifications.push({ roomId, count: memberCount })
       } else {
-        // Schedule empty room cleanup
-        setTimeout(() => {
-          const currentRoom = this.rooms.get(roomId)
-          if (currentRoom && currentRoom.members.size === 0) {
-            // Call onDestroy for LiveRoom-backed rooms
-            if (currentRoom.instance) {
-              const result = currentRoom.instance.onDestroy()
-              if (result === false) return // Room wants to stay alive
-            }
-            this.rooms.delete(roomId)
-            liveLog('rooms', null, `Room '${roomId}' destroyed (empty)`)
-          }
-        }, 5 * 60 * 1000)
+        // Schedule empty room cleanup (awaits onDestroy properly — see #5 H5)
+        this.scheduleEmptyRoomDestruction(roomId)
       }
     }
 
@@ -348,11 +396,29 @@ export class LiveRoomManager {
     const now = Date.now()
     room.lastActivity = now
 
-    // 0. Call onEvent lifecycle hook for LiveRoom-backed rooms
+    // 0. Call onEvent lifecycle hook for LiveRoom-backed rooms.
+    //
+    // Contract (fixes #5 H3/H4): onEvent is an *observer*, not an interceptor.
+    // `emitToRoom` is synchronous and the broadcast below cannot be cancelled
+    // or modified by the hook's return value. We still accept Promise-returning
+    // hooks to keep the existing signature compatible, but they run
+    // fire-and-forget and their rejection is logged rather than propagated.
+    // Synchronous throws are also isolated so a single broken handler cannot
+    // block the RoomEventBus emit, the cluster pubsub publish, or the
+    // WebSocket broadcast below.
     if (room.instance) {
-      room.instance.onEvent(event, data, {
-        componentId: excludeComponentId ?? 'server',
-      })
+      try {
+        const res = room.instance.onEvent(event, data, {
+          componentId: excludeComponentId ?? 'server',
+        })
+        if (res && typeof (res as Promise<void>).catch === 'function') {
+          ;(res as Promise<void>).catch((err) => {
+            liveWarn('rooms', null, `Room '${roomId}' onEvent('${event}') async rejection: ${err?.message || err}`)
+          })
+        }
+      } catch (err: any) {
+        liveWarn('rooms', null, `Room '${roomId}' onEvent('${event}') threw: ${err?.message || err}`)
+      }
     }
 
     // 1. Emit on RoomEventBus for server-side handlers


### PR DESCRIPTION
Closes #5.

## Summary

Five related bugs in `LiveRoomManager`, all surfaced by the preventive bug-hunt suite. Every user-facing lifecycle hook on `LiveRoom` (`onCreate`, `onJoin`, `onEvent`, `onLeave`, `onDestroy`) used to be invoked without isolation.

1. **`onCreate`** — now runs **before** the first `onJoin`, with `try/catch + await`. Contradicted `LiveRoom.ts:148` docs; throws/rejections used to propagate out of `joinRoom`.
2. **`onJoin`** — throws are now caught and treated as an implicit rejection (same as `return false`), with the same teardown path.
3. **`onEvent`** — observer-only contract made explicit. Sync throws and async rejections are caught and logged via `liveWarn`; the broadcast is never gated on user code.
4. **`onDestroy`** — now `await`ed. `Promise<false>` properly cancels destruction (was silently ignored because `Promise !== false`). The two duplicated `setTimeout` blocks in `leaveRoom` and `cleanupComponent` were consolidated into a private `scheduleEmptyRoomDestruction` helper.
5. **`onLeave`** — throws are isolated per-iteration in `cleanupComponent` so a single bad hook cannot prevent the rest of the rooms from being cleaned (previously caused a member leak + skipped `componentRooms.delete`). Same protection added to the single-room `leaveRoom()` path.

## Files changed

- `packages/core/src/rooms/LiveRoomManager.ts` — all five fixes, new `scheduleEmptyRoomDestruction` helper, `liveWarn` import
- `packages/core/src/__tests__/rooms/LiveRoomManager.lifecycle-hooks.test.ts` — new regression suite (14 tests, 1 intentionally skipped for the documented `onStateChange` reentrancy guard)

## Test plan

- [x] `bunx tsc -p packages/core/tsconfig.json --noEmit` clean
- [x] 13/13 new lifecycle tests passing (1 documented skip)
- [x] Full suite: **552/552** passing on core/react/client (no regressions)
- [x] `bun run build:core` clean

## Notes for reviewers

- **Behavior change**: `onJoin` throwing used to crash the transport layer (bug). It now rejects the join cleanly. Any code that relied on `onJoin` throwing to surface errors needs to use the `{ rejected: true, reason }` return path or log inside the hook.
- **Behavior change**: `onCreate` now runs **before** `onJoin` for the first member. Any room that relied on the old (buggy) order where `onJoin` ran first needs to move its first-member initialization into `onCreate` — which is what the docs already said to do.
- **`onEvent` async semantics**: documented as observer-only. The hook can still be declared `async` but its completion is not awaited before the broadcast. This matches the existing synchronous `emitToRoom` signature and keeps the broadcast path non-blocking.
- `scheduleEmptyRoomDestruction` is a private helper; the public surface of `LiveRoomManager` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)