### PR TITLE
fix(state): top-level null is a real value, undefined is a no-op (fixes #6)

### DIFF
--- a/packages/client/src/component.ts
+++ b/packages/client/src/component.ts
@@ -20,7 +20,19 @@ function isPlainObject(v: unknown): v is Record<string, any> {
     && Object.getPrototypeOf(v) === Object.prototype
 }
 
+/**
+ * Apply a STATE_DELTA coming from the server (component state).
+ *
+ * Semantics (matches core's `deepAssign`, fixes #6):
+ * - Top-level `null` is a real value (set to null).
+ * - Nested `null` is the deletion sentinel from `computeDeepDiff`.
+ * - `undefined` is skipped — it never crosses the wire.
+ */
 function deepMerge<T extends Record<string, any>>(target: T, source: Partial<T>, seen?: Set<object>): T {
+  return deepMergeImpl(target, source, 0, seen)
+}
+
+function deepMergeImpl<T extends Record<string, any>>(target: T, source: Partial<T>, depth: number, seen?: Set<object>): T {
   if (!seen) seen = new Set()
   if (seen.has(source as object)) return target
   seen.add(source as object)
@@ -28,13 +40,18 @@ function deepMerge<T extends Record<string, any>>(target: T, source: Partial<T>,
   const result = { ...target }
   for (const key of Object.keys(source) as Array<keyof T>) {
     const newVal = source[key]
+    if (newVal === undefined) continue
     if (newVal === null) {
-      delete result[key]
+      if (depth === 0) {
+        result[key] = null as T[keyof T]
+      } else {
+        delete result[key]
+      }
       continue
     }
     const oldVal = result[key]
     if (isPlainObject(oldVal) && isPlainObject(newVal)) {
-      result[key] = deepMerge(oldVal as any, newVal as any, seen)
+      result[key] = deepMergeImpl(oldVal as any, newVal as any, depth + 1, seen) as T[keyof T]
     } else {
       result[key] = newVal as T[keyof T]
     }

--- a/packages/client/src/rooms.ts
+++ b/packages/client/src/rooms.ts
@@ -10,7 +10,19 @@ function isPlainObject(v: unknown): v is Record<string, any> {
     && Object.getPrototypeOf(v) === Object.prototype
 }
 
+/**
+ * Apply a room STATE_DELTA coming from the server.
+ *
+ * Semantics (matches core's `deepAssign`, fixes #6):
+ * - Top-level `null` is a real value (set to null).
+ * - Nested `null` is the deletion sentinel from `computeDeepDiff`.
+ * - `undefined` is skipped — it never crosses the wire.
+ */
 function deepMerge<T extends Record<string, any>>(target: T, source: Partial<T>, seen?: Set<object>): T {
+  return deepMergeImpl(target, source, 0, seen)
+}
+
+function deepMergeImpl<T extends Record<string, any>>(target: T, source: Partial<T>, depth: number, seen?: Set<object>): T {
   if (!seen) seen = new Set()
   if (seen.has(source as object)) return target
   seen.add(source as object)
@@ -18,13 +30,18 @@ function deepMerge<T extends Record<string, any>>(target: T, source: Partial<T>,
   const result = { ...target }
   for (const key of Object.keys(source) as Array<keyof T>) {
     const newVal = source[key]
+    if (newVal === undefined) continue
     if (newVal === null) {
-      delete result[key]
+      if (depth === 0) {
+        result[key] = null as T[keyof T]
+      } else {
+        delete result[key]
+      }
       continue
     }
     const oldVal = result[key]
     if (isPlainObject(oldVal) && isPlainObject(newVal)) {
-      result[key] = deepMerge(oldVal as any, newVal as any, seen)
+      result[key] = deepMergeImpl(oldVal as any, newVal as any, depth + 1, seen) as T[keyof T]
     } else {
       result[key] = newVal as T[keyof T]
     }

--- a/packages/core/src/__tests__/component/setstate-edge-cases.test.ts
+++ b/packages/core/src/__tests__/component/setstate-edge-cases.test.ts
@@ -1,0 +1,367 @@
+// Regression suite for issue #6 edge cases in setState / computeDeepDiff /
+// deepAssign. Originally bug-hunt/setstate-edge-cases.test.ts; promoted here
+// after the fixes for top-level null and undefined drift.
+//
+// Sections:
+//   - "fixes #6": assertions encode the post-fix behaviour.
+//   - "documented limitations": behaviours that are intentional and have
+//     no fix today (shallow proxy, Map/Set-as-state, Date reference compare).
+//     Captured here so any future change is an explicit decision.
+//   - "existing behaviour preserved": other edge cases that already worked
+//     but are cheap to keep locked down.
+
+import { describe, it, expect, vi } from 'vitest'
+import { LiveComponent } from '../../component/LiveComponent'
+import { computeDeepDiff, deepAssign } from '../../utils/deepDiff'
+import type { FluxStackWebSocket } from '../../transport/types'
+
+// ===== Helpers (adapted from ComponentStateManager.deepDiff.test.ts) =====
+
+function createMockWs(): FluxStackWebSocket {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: 1,
+    data: {} as any,
+    remoteAddress: '127.0.0.1',
+  } as any
+}
+
+const flush = () => new Promise<void>(r => queueMicrotask(r))
+
+function extractDeltas(ws: FluxStackWebSocket): any[] {
+  const deltas: any[] = []
+  for (const call of (ws.send as any).mock.calls) {
+    try {
+      const parsed = JSON.parse(call[0])
+      const messages = Array.isArray(parsed) ? parsed : [parsed]
+      for (const msg of messages) {
+        if (msg.type === 'STATE_DELTA') {
+          deltas.push(msg.payload.delta)
+        }
+      }
+    } catch {}
+  }
+  return deltas
+}
+
+// ==========================================================================
+// fixes #6 — setState({ x: null }) preserves the null value
+// ==========================================================================
+describe('fixes #6: top-level null is a real value, not a deletion', () => {
+  it('setState({ selected: null }) keeps the key and stores null on the server', async () => {
+    type S = { selected: { id: string } | null; other: number }
+    class C extends LiveComponent<S> {
+      static componentName = 'NullTopLevelComponent'
+      static publicActions = [] as const
+      static defaultState: S = { selected: { id: 'abc' }, other: 1 }
+    }
+    const ws = createMockWs()
+    const comp = new C({}, ws)
+
+    comp.setState({ selected: null })
+    await flush()
+
+    const state = comp.getSerializableState() as any
+    expect('selected' in state).toBe(true)
+    expect(state.selected).toBeNull()
+
+    // And the delta carries the null through to the wire so the client
+    // can apply it (client-side deepMerge also knows top-level null = set).
+    const deltas = extractDeltas(ws)
+    expect(deltas.length).toBe(1)
+    expect(deltas[0]).toEqual({ selected: null })
+  })
+
+  it('setState({ x: null }) when x was already a primitive', async () => {
+    type S = { label: string | null }
+    class C extends LiveComponent<S> {
+      static componentName = 'NullPrimitiveComponent'
+      static publicActions = [] as const
+      static defaultState: S = { label: 'hello' }
+    }
+    const ws = createMockWs()
+    const comp = new C({}, ws)
+
+    comp.setState({ label: null })
+    await flush()
+
+    expect((comp.getSerializableState() as any).label).toBeNull()
+    const deltas = extractDeltas(ws)
+    expect(deltas[0]).toEqual({ label: null })
+  })
+
+  it('nested null in a Record<string, T> still deletes the key', async () => {
+    // The issue #1/#3 scenario: player B leaves a game room. This is the
+    // whole reason deepAssign has null-as-deletion semantics in nested
+    // contexts. The top-level fix in #6 must not break this.
+    type Player = { name: string; x: number }
+    type S = { players: Record<string, Player>; hostId: string }
+    class C extends LiveComponent<S> {
+      static componentName = 'NestedNullComponent'
+      static publicActions = [] as const
+      static defaultState: S = {
+        players: { A: { name: 'A', x: 0 }, B: { name: 'B', x: 5 } },
+        hostId: 'A',
+      }
+    }
+    const ws = createMockWs()
+    const comp = new C({}, ws)
+
+    comp.setState({
+      players: { A: { name: 'A', x: 1 } },
+      hostId: 'A',
+    })
+    await flush()
+
+    const state = comp.getSerializableState() as any
+    expect('B' in state.players).toBe(false)
+    expect(state.players).toEqual({ A: { name: 'A', x: 1 } })
+
+    const deltas = extractDeltas(ws)
+    expect(deltas.length).toBe(1)
+    // computeDeepDiff at depth > 0 emits null for removed B, and only
+    // the changed A.x field.
+    expect(deltas[0]).toEqual({ players: { A: { x: 1 }, B: null } })
+  })
+})
+
+// ==========================================================================
+// fixes #6 — undefined never crosses the wire
+// ==========================================================================
+describe('fixes #6: undefined values are skipped server-side to avoid wire drift', () => {
+  it('setState({ x: undefined, y: 2 }) applies y and leaves x untouched', async () => {
+    type S = { x: number; y: number }
+    class C extends LiveComponent<S> {
+      static componentName = 'UndefinedComponent'
+      static publicActions = [] as const
+      static defaultState: S = { x: 42, y: 1 }
+    }
+    const ws = createMockWs()
+    const comp = new C({}, ws)
+
+    comp.setState({ x: undefined as any, y: 2 })
+    await flush()
+
+    const state = comp.getSerializableState() as any
+    // x unchanged (undefined was a no-op)
+    expect(state.x).toBe(42)
+    expect(state.y).toBe(2)
+
+    const deltas = extractDeltas(ws)
+    expect(deltas.length).toBe(1)
+    // The delta only carries y — undefined is never emitted.
+    expect(deltas[0]).toEqual({ y: 2 })
+    expect('x' in deltas[0]).toBe(false)
+  })
+
+  it('deepAssign with undefined in the source leaves target untouched', () => {
+    const target: Record<string, unknown> = { a: 1, b: 2 }
+    deepAssign(target, { a: undefined })
+    expect(target).toEqual({ a: 1, b: 2 })
+    expect('a' in target).toBe(true)
+    expect(target.a).toBe(1)
+  })
+})
+
+// ==========================================================================
+// Regression coverage for existing correct behaviour
+// ==========================================================================
+describe('regression: back-to-back setStates land on the wire', () => {
+  it('two setStates in same tick both reach the wire', async () => {
+    type S = { a: number; b: number }
+    class C extends LiveComponent<S> {
+      static componentName = 'BackToBackComponent'
+      static publicActions = [] as const
+      static defaultState: S = { a: 0, b: 0 }
+    }
+    const ws = createMockWs()
+    const comp = new C({}, ws)
+
+    comp.setState({ a: 1 })
+    comp.setState({ b: 2 })
+    await flush()
+
+    const deltas = extractDeltas(ws)
+    const merged = Object.assign({}, ...deltas)
+    expect(merged.a).toBe(1)
+    expect(merged.b).toBe(2)
+  })
+})
+
+describe('regression: shared sub-tree in next is diffed on both paths', () => {
+  it('two keys pointing at the same new object both produce deltas', async () => {
+    type S = { a: { count: number }; b: { count: number } }
+    class C extends LiveComponent<S> {
+      static componentName = 'SharedSubtreeComponent'
+      static publicActions = [] as const
+      static defaultState: S = { a: { count: 0 }, b: { count: 0 } }
+    }
+    const ws = createMockWs()
+    const comp = new C({}, ws)
+
+    const shared = { count: 9 }
+    comp.setState({ a: shared, b: shared })
+    await flush()
+
+    const deltas = extractDeltas(ws)
+    expect(deltas.length).toBe(1)
+    expect(deltas[0]).toHaveProperty('a')
+    expect(deltas[0]).toHaveProperty('b')
+  })
+})
+
+describe('regression: maxDepth boundary does not leak user references', () => {
+  it('mutating the original update object after setState does not corrupt state', async () => {
+    type S = { l1: { l2: { l3: { l4: { val: number } } } } }
+    class C extends LiveComponent<S> {
+      static componentName = 'MaxDepthComponent'
+      static publicActions = [] as const
+      static defaultState: S = { l1: { l2: { l3: { l4: { val: 0 } } } } }
+    }
+    const ws = createMockWs()
+    const comp = new C({}, ws)
+
+    const userUpdate = { l1: { l2: { l3: { l4: { val: 42 } } } } }
+    comp.setState(userUpdate)
+    await flush()
+
+    userUpdate.l1.l2.l3.l4.val = 999
+    const state = comp.getSerializableState() as any
+    expect(state.l1.l2.l3.l4.val).toBe(42)
+  })
+})
+
+describe('regression: setState with the same reference object is a no-op', () => {
+  it('passing the current state object emits nothing', async () => {
+    type S = { obj: { a: number; b: number } }
+    class C extends LiveComponent<S> {
+      static componentName = 'SameRefComponent'
+      static publicActions = [] as const
+      static defaultState: S = { obj: { a: 1, b: 2 } }
+    }
+    const ws = createMockWs()
+    const comp = new C({}, ws)
+
+    const currentObj = (comp.getSerializableState() as any).obj
+    comp.setState({ obj: currentObj })
+    await flush()
+
+    expect(extractDeltas(ws).length).toBe(0)
+  })
+})
+
+describe('regression: array replacement inside nested object', () => {
+  it('new array ref inside nested plain object is emitted whole', async () => {
+    type S = { list: { items: number[]; title: string } }
+    class C extends LiveComponent<S> {
+      static componentName = 'ArrayInNestedComponent'
+      static publicActions = [] as const
+      static defaultState: S = { list: { items: [1, 2, 3], title: 'todo' } }
+    }
+    const ws = createMockWs()
+    const comp = new C({}, ws)
+
+    comp.setState({ list: { items: [1, 2, 3, 4], title: 'todo' } })
+    await flush()
+
+    const deltas = extractDeltas(ws)
+    expect(deltas.length).toBe(1)
+    expect(deltas[0]).toEqual({ list: { items: [1, 2, 3, 4] } })
+  })
+})
+
+describe('regression: top-level key removal is not emitted (documented)', () => {
+  // Top-level state keys are part of the component schema. Adding/removing
+  // them dynamically is not supported; only nested Record<string,T> maps
+  // get deletion semantics. computeDeepDiff encodes this by only emitting
+  // removals at depth > 0.
+
+  it('computeDeepDiff at depth 0 does not emit removals', () => {
+    const prev = { a: 1, b: 2, c: 3 }
+    const next = { a: 1, b: 2 }
+    const diff = computeDeepDiff(prev, next)
+    expect(diff).toBeNull()
+  })
+
+  it('computeDeepDiff at depth > 0 DOES emit removals', () => {
+    const prev = { outer: { a: 1, b: 2, c: 3 } }
+    const next = { outer: { a: 1, b: 2 } }
+    const diff = computeDeepDiff(prev, next)
+    expect(diff).toEqual({ outer: { c: null } })
+  })
+})
+
+// ==========================================================================
+// Documented limitations — not bugs, captured here so changes are explicit
+// ==========================================================================
+describe('documented limitation: shallow proxy does not intercept nested mutations', () => {
+  // `this.state.nested.x = 42` mutates the internal state but emits no
+  // delta because the state proxy only traps top-level set. The fix for
+  // users is to call `this.setState({ nested: { ...this.state.nested, x: 42 } })`.
+  // A recursive proxy would be a breaking change + perf hit; a dev warning
+  // would need to detect nested writes without slowing the hot path. Both
+  // are out of scope for #6.
+  it('mutating nested fields via the state proxy emits no delta', async () => {
+    type S = { nested: { x: number } }
+    class C extends LiveComponent<S> {
+      static componentName = 'ShallowProxyComponent'
+      static publicActions = [] as const
+      static defaultState: S = { nested: { x: 0 } }
+    }
+    const ws = createMockWs()
+    const comp = new C({}, ws)
+
+    const state = comp.getSerializableState() as any
+    state.nested.x = 42
+    await flush()
+
+    expect(extractDeltas(ws).length).toBe(0)
+    expect((comp.getSerializableState() as any).nested.x).toBe(42)
+  })
+})
+
+describe('documented limitation: Map/Set as state values serialize to empty objects', () => {
+  // `JSON.stringify(new Map())` returns `{}`. We do not reject Maps at
+  // runtime — the framework would need a type-system-level guarantee or a
+  // blanket deep inspection to do so correctly. Users are expected to keep
+  // state JSON-serializable; see README.
+  it('a Map put into state serializes as {} on the wire', async () => {
+    type S = { cache: Map<string, number>; n: number }
+    class C extends LiveComponent<S> {
+      static componentName = 'MapStateComponent'
+      static publicActions = [] as const
+      static defaultState: S = { cache: new Map(), n: 0 }
+    }
+    const ws = createMockWs()
+    const comp = new C({}, ws)
+
+    comp.setState({ cache: new Map<string, number>([['k', 1]]) })
+    await flush()
+
+    const deltas = extractDeltas(ws)
+    expect(deltas.length).toBe(1)
+    expect(deltas[0].cache).toEqual({})
+  })
+})
+
+describe('documented limitation: Date values are reference-compared', () => {
+  // Two equivalent Date instances produce a delta because `computeDeepDiff`
+  // uses `===` for non-plain values. Users who care about wall-clock
+  // equality should store timestamps as numbers (Date.now()) in state.
+  it('two equal-by-time Date instances (different refs) emit a delta', async () => {
+    type S = { updatedAt: Date; count: number }
+    class C extends LiveComponent<S> {
+      static componentName = 'DateStateComponent'
+      static publicActions = [] as const
+      static defaultState: S = { updatedAt: new Date(1000), count: 0 }
+    }
+    const ws = createMockWs()
+    const comp = new C({}, ws)
+
+    comp.setState({ updatedAt: new Date(1000) })
+    await flush()
+
+    expect(extractDeltas(ws).length).toBe(1)
+  })
+})

--- a/packages/core/src/__tests__/utils/deepDiff.test.ts
+++ b/packages/core/src/__tests__/utils/deepDiff.test.ts
@@ -134,25 +134,54 @@ describe('computeDeepDiff', () => {
 })
 
 describe('deepAssign', () => {
-  describe('null as deletion signal', () => {
-    it('deletes key when value is null', () => {
-      const target = { a: 1, b: 2, c: 3 }
+  describe('null semantics (top-level = value, nested = deletion)', () => {
+    // Fixes #6: null at the top level is a real value, not a delete signal.
+    // The delete semantics still apply inside nested objects where
+    // computeDeepDiff uses null as the "removed key" sentinel for
+    // Record<string, T> maps (issue #1/#3).
+
+    it('top-level null sets the key to null (not deletion)', () => {
+      const target: Record<string, unknown> = { a: 1, b: 2, c: 3 }
       deepAssign(target, { b: null })
-      expect(target).toEqual({ a: 1, c: 3 })
-      expect('b' in target).toBe(false)
+      expect(target).toEqual({ a: 1, b: null, c: 3 })
+      expect('b' in target).toBe(true)
+      expect(target.b).toBeNull()
     })
 
-    it('deletes nested key when value is null', () => {
+    it('nested null deletes the key (from computeDeepDiff sentinel)', () => {
       const target = { players: { A: { score: 1 }, B: { score: 2 } } }
       deepAssign(target, { players: { B: null } })
       expect(target).toEqual({ players: { A: { score: 1 } } })
       expect('B' in target.players).toBe(false)
     })
 
-    it('handles mixed updates and deletions', () => {
-      const target = { x: 1, y: 2, z: 3 }
-      deepAssign(target, { x: 10, y: null, w: 4 } as any)
-      expect(target).toEqual({ x: 10, z: 3, w: 4 })
+    it('mixes top-level null-as-value with nested null-as-deletion', () => {
+      const target: Record<string, unknown> = {
+        selected: { id: 'x' },
+        players: { A: { score: 1 }, B: { score: 2 } },
+      }
+      deepAssign(target, {
+        selected: null,            // top-level → set to null
+        players: { B: null },      // nested → delete B
+      } as any)
+      expect(target).toEqual({
+        selected: null,
+        players: { A: { score: 1 } },
+      })
+      expect('selected' in target).toBe(true)
+      expect('B' in (target.players as any)).toBe(false)
+    })
+
+    it('top-level null overwrites a non-object value', () => {
+      const target = { name: 'alice' as string | null }
+      deepAssign(target, { name: null })
+      expect(target.name).toBeNull()
+    })
+
+    it('top-level null overwrites a plain-object value (replaces, does not merge)', () => {
+      const target = { settings: { volume: 5 } as { volume: number } | null }
+      deepAssign(target, { settings: null })
+      expect(target.settings).toBeNull()
     })
 
     it('applies full round-trip: diff then assign', () => {
@@ -182,6 +211,29 @@ describe('deepAssign', () => {
     })
   })
 
+  describe('undefined is a no-op (fixes #6 server↔wire drift)', () => {
+    // JSON.stringify strips `undefined`, so if the server accepted it we
+    // would silently desync from the client. deepAssign now skips it.
+
+    it('top-level undefined does not change the target', () => {
+      const target: Record<string, unknown> = { a: 1, b: 2 }
+      deepAssign(target, { a: undefined })
+      expect(target).toEqual({ a: 1, b: 2 })
+    })
+
+    it('nested undefined does not change the target', () => {
+      const target = { settings: { volume: 5, mute: false } }
+      deepAssign(target, { settings: { volume: undefined } } as any)
+      expect(target).toEqual({ settings: { volume: 5, mute: false } })
+    })
+
+    it('undefined mixed with real updates applies only the real ones', () => {
+      const target: Record<string, unknown> = { a: 1, b: 2, c: 3 }
+      deepAssign(target, { a: 10, b: undefined, d: 4 } as any)
+      expect(target).toEqual({ a: 10, b: 2, c: 3, d: 4 })
+    })
+  })
+
   describe('existing behavior preserved', () => {
     it('merges plain objects recursively', () => {
       const target = { a: { x: 1, y: 2 }, b: 3 }
@@ -200,5 +252,29 @@ describe('deepAssign', () => {
       deepAssign(target, { b: 2 })
       expect(target).toEqual({ a: 1, b: 2 })
     })
+  })
+})
+
+describe('computeDeepDiff — undefined handling (fixes #6)', () => {
+  it('skips undefined values in the update (never emits them)', () => {
+    const prev = { a: 1, b: 2 }
+    const next = { a: 10, b: undefined } as any
+    const diff = computeDeepDiff(prev, next)
+    expect(diff).toEqual({ a: 10 })
+    expect(diff).not.toHaveProperty('b')
+  })
+
+  it('top-level null is emitted normally (real value, not a removal)', () => {
+    const prev = { selected: { id: 'x' } as { id: string } | null }
+    const next = { selected: null }
+    const diff = computeDeepDiff(prev as any, next as any)
+    expect(diff).toEqual({ selected: null })
+  })
+
+  it('top-level null is unchanged if prev was already null', () => {
+    const prev = { selected: null }
+    const next = { selected: null }
+    const diff = computeDeepDiff(prev as any, next as any)
+    expect(diff).toBeNull()
   })
 })

--- a/packages/core/src/utils/deepDiff.ts
+++ b/packages/core/src/utils/deepDiff.ts
@@ -14,8 +14,21 @@ export function isPlainObject(v: unknown): v is Record<string, unknown> {
 /**
  * Recursively compute the diff between two plain objects.
  * Returns null if nothing changed, or an object with only the changed keys.
- * Keys present in `prev` but absent in `next` are emitted as `null` (deletion signal).
- * Arrays are compared by reference (===).
+ *
+ * Semantics (fixes #6):
+ * - Arrays are compared by reference (===). A new array reference produces
+ *   a full replacement in the delta.
+ * - `undefined` values in `next` are skipped entirely. They would desync
+ *   server↔wire (JSON strips undefined) so we never include them in the
+ *   delta. Callers wanting to "clear" a field should pass `null` if the
+ *   type allows it, or use a typed sentinel.
+ * - `null` is treated as a regular value in top-level (depth === 0): if the
+ *   old value was non-null, the delta carries `{ key: null }` and the
+ *   server/client apply it as a real null via `deepAssign`.
+ * - At nested depths (depth > 0), keys present in `prev` but absent in
+ *   `next` are emitted as `null` — this is the deletion sentinel the
+ *   `Record<string, T>` scenario from issue #1/#3 relies on.
+ *
  * Safe against circular references (tracked via `seen` Set).
  *
  * @param maxDepth - Maximum recursion depth (default: 3). Beyond this, falls back to reference equality.
@@ -38,6 +51,10 @@ export function computeDeepDiff(
   for (const key of Object.keys(next)) {
     const oldVal = prev[key]
     const newVal = next[key]
+
+    // Skip undefined entirely — it would be stripped by JSON.stringify
+    // on the wire, creating server↔client drift.
+    if (newVal === undefined) continue
 
     if (oldVal === newVal) continue
 
@@ -71,22 +88,53 @@ export function computeDeepDiff(
 
 /**
  * Recursively merge source into target (mutates target).
- * Plain objects are merged recursively; everything else is overwritten.
- * A `null` value in source deletes the corresponding key from target.
+ *
+ * Semantics (fixes #6):
+ * - At the TOP LEVEL (depth === 0), `null` is a real value: `target[key]`
+ *   is set to `null`. Top-level state keys come from the component's
+ *   `defaultState` schema — they are not dynamically added/removed by the
+ *   user, so there is no ambiguity with a "delete" signal here. This is
+ *   what lets `Nullable<T>` state fields work in `setState({ x: null })`.
+ * - At NESTED levels (depth > 0), `null` is the deletion sentinel emitted
+ *   by `computeDeepDiff` when a key is removed from a `Record<string, T>`
+ *   map: `delete target[key]`. This is what issue #1/#3 needed.
+ * - Plain objects are merged recursively; everything else is overwritten.
+ * - `undefined` is a no-op (skipped) to avoid server↔wire drift: JSON
+ *   serialization strips `undefined`, so accepting it on the server would
+ *   leave the two sides out of sync.
+ *
  * Safe against circular references (tracked via `seen` Set).
  */
 export function deepAssign(target: any, source: any, seen?: Set<object>): void {
+  deepAssignImpl(target, source, 0, seen)
+}
+
+function deepAssignImpl(target: any, source: any, depth: number, seen?: Set<object>): void {
   if (!seen) seen = new Set()
   if (seen.has(source)) return
   seen.add(source)
 
   for (const key of Object.keys(source)) {
-    if (source[key] === null) {
-      delete target[key]
-    } else if (isPlainObject(target[key]) && isPlainObject(source[key])) {
-      deepAssign(target[key], source[key], seen)
+    const value = source[key]
+    if (value === undefined) {
+      // No-op: JSON.stringify would strip this, so accepting it on the
+      // server would silently desync from the client.
+      continue
+    }
+    if (value === null) {
+      if (depth === 0) {
+        // Top-level: set the key to null (real value).
+        target[key] = null
+      } else {
+        // Nested: deletion sentinel from computeDeepDiff — remove the key.
+        delete target[key]
+      }
+      continue
+    }
+    if (isPlainObject(target[key]) && isPlainObject(value)) {
+      deepAssignImpl(target[key], value, depth + 1, seen)
     } else {
-      target[key] = source[key]
+      target[key] = value
     }
   }
 }

--- a/packages/react/src/hooks/useLiveComponent.ts
+++ b/packages/react/src/hooks/useLiveComponent.ts
@@ -29,7 +29,24 @@ function isPlainObject(v: unknown): v is Record<string, any> {
     && Object.getPrototypeOf(v) === Object.prototype
 }
 
+/**
+ * Apply a STATE_DELTA coming from the server.
+ *
+ * Semantics (matches core's `deepAssign`, fixes #6):
+ * - Top-level (depth === 0): `null` is a real value — `result[key] = null`.
+ *   Top-level state keys are part of the component schema and are not
+ *   dynamically added/removed, so there is no ambiguity with a deletion
+ *   signal.
+ * - Nested (depth > 0): `null` is the deletion sentinel from the core's
+ *   `computeDeepDiff` — remove the key. This is what the
+ *   `Record<string, T>` scenario from issue #1/#3 relies on.
+ * - `undefined` is a no-op (skipped) — these values don't cross the wire.
+ */
 function deepMerge<T extends Record<string, any>>(target: T, source: Partial<T>, seen?: Set<object>): T {
+  return deepMergeImpl(target, source, 0, seen)
+}
+
+function deepMergeImpl<T extends Record<string, any>>(target: T, source: Partial<T>, depth: number, seen?: Set<object>): T {
   if (!seen) seen = new Set()
   if (seen.has(source as object)) return target
   seen.add(source as object)
@@ -37,13 +54,18 @@ function deepMerge<T extends Record<string, any>>(target: T, source: Partial<T>,
   const result = { ...target }
   for (const key of Object.keys(source) as Array<keyof T>) {
     const newVal = source[key]
+    if (newVal === undefined) continue
     if (newVal === null) {
-      delete result[key]
+      if (depth === 0) {
+        result[key] = null as T[keyof T]
+      } else {
+        delete result[key]
+      }
       continue
     }
     const oldVal = result[key]
     if (isPlainObject(oldVal) && isPlainObject(newVal)) {
-      result[key] = deepMerge(oldVal as any, newVal as any, seen)
+      result[key] = deepMergeImpl(oldVal as any, newVal as any, depth + 1, seen) as T[keyof T]
     } else {
       result[key] = newVal as T[keyof T]
     }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -36,19 +36,41 @@ function isPlainObject(v: unknown): v is Record<string, any> {
     && Object.getPrototypeOf(v) === Object.prototype
 }
 
+/**
+ * Apply a STATE_DELTA coming from the server (mutates target).
+ *
+ * Semantics (matches core's `deepAssign`, fixes #6):
+ * - Top-level (depth === 0): `null` is a real value — `target[key] = null`.
+ *   Top-level state keys are part of the component schema and are not
+ *   dynamically added/removed, so there is no ambiguity with a deletion
+ *   signal. This is what makes `Nullable<T>` fields in state work.
+ * - Nested (depth > 0): `null` is the deletion sentinel from the core's
+ *   `computeDeepDiff` — remove the key. This is what the
+ *   `Record<string, T>` scenario from issue #1/#3 relies on.
+ * - `undefined` is a no-op (skipped) — these values never cross the wire.
+ */
 function deepMerge(target: Record<string, any>, source: Record<string, any>, seen?: Set<object>): void {
+  deepMergeImpl(target, source, 0, seen)
+}
+
+function deepMergeImpl(target: Record<string, any>, source: Record<string, any>, depth: number, seen?: Set<object>): void {
   if (!seen) seen = new Set()
   if (seen.has(source)) return
   seen.add(source)
 
   for (const key of Object.keys(source)) {
     const newVal = source[key]
+    if (newVal === undefined) continue
     if (newVal === null) {
-      delete target[key]
+      if (depth === 0) {
+        target[key] = null
+      } else {
+        delete target[key]
+      }
       continue
     }
     if (isPlainObject(target[key]) && isPlainObject(newVal)) {
-      deepMerge(target[key], newVal, seen)
+      deepMergeImpl(target[key], newVal, depth + 1, seen)
     } else {
       target[key] = newVal
     }


### PR DESCRIPTION
Closes #6.

## Summary

Two regressions in the state-delta pipeline introduced while fixing #1/#3. Both caused silent server↔client drift and had the same root cause: `deepAssign`/`deepMerge` treated `null` as a "delete" sentinel at every depth, and handled `undefined` as an overwrite — even though `JSON.stringify` strips `undefined` on the wire.

## 1. Top-level null is a real value (the #3 regression)

`setState({ selected: null })` used to **delete** the `selected` key from state because `deepAssign` saw `null` and called `delete target[key]`. Any `Nullable<Object>` field was impossible to express — the user wrote "set to null" and the framework removed the key on both sides.

The fix distinguishes depth:

- **Top-level (depth === 0)**: `null` is a real value. `target[key] = null`. Top-level keys come from `defaultState` and are not dynamically added/removed, so there is no ambiguity with a delete signal.
- **Nested (depth > 0)**: `null` is still the deletion sentinel emitted by `computeDeepDiff` when a key is removed from a `Record<string, T>` map. This is what issue #1/#3 originally needed and what game rooms rely on.

Applied in all **five** deep-merge implementations so server and client agree:

- `packages/core/src/utils/deepDiff.ts`
- `packages/react/src/hooks/useLiveComponent.ts`
- `packages/vue/src/index.ts`
- `packages/client/src/component.ts`
- `packages/client/src/rooms.ts`

## 2. undefined is a no-op (never crosses the wire)

`setState({ x: undefined })` used to set `_state.x = undefined` and emit `{ x: undefined }` in the delta. `JSON.stringify` then stripped it, so the client never saw any change while the server sat on `undefined` forever. Both `computeDeepDiff` and `deepAssign` now skip `undefined` values entirely. Callers wanting to clear a field should pass `null` if the type allows it.

## Out of scope (documented as known limitations)

The bug hunt flagged three more edge cases that I looked at but chose **not** to fix in this PR. Each is pinned as a test under "documented limitation" in the regression suite so any future change is an explicit decision:

- **Shallow proxy** — `this.state.nested.x = y` emits no delta. A recursive proxy is a breaking change + perf hit; a dev warning would need to detect nested writes without slowing the hot path. Users should call `setState({ nested: { ...this.state.nested, x } })`.
- **Map / Set as state values** — they serialize to `{}` on the wire. Detecting this at runtime would require deep inspection on every `setState`. State must stay JSON-serializable; README covers this.
- **Date reference-compare** — two equivalent Date instances emit a delta because `computeDeepDiff` uses `===` for non-plain values. Users caring about wall-clock equality should store `Date.now()` numbers.

## Files changed

- `packages/core/src/utils/deepDiff.ts` — depth-aware `deepAssign` + skip `undefined` in `computeDeepDiff`
- `packages/react/src/hooks/useLiveComponent.ts` — matching `deepMerge`
- `packages/vue/src/index.ts` — matching `deepMerge`
- `packages/client/src/component.ts` — matching `deepMerge`
- `packages/client/src/rooms.ts` — matching `deepMerge`

## Regression suites

- `packages/core/src/__tests__/component/setstate-edge-cases.test.ts` (new, 15 tests)
- `packages/core/src/__tests__/utils/deepDiff.test.ts` updated with 8 new cases

Two pre-existing tests that expected top-level `null` to delete the key were updated to match the new contract — their old behaviour was the bug.

## Test plan

- [x] `bunx tsc -p packages/core/tsconfig.json --noEmit` clean
- [x] `tsc` clean in react, vue, client
- [x] 15/15 new tests passing
- [x] Full suite: **585/585** passing (2 skipped intentional) on core / react / client / elysia / express / fastify / vue
- [x] `bun run build:core`, `build:client`, `build:react` clean

## Notes for reviewers

- **Semantic change that could affect users**: if any consumer was relying on `setState({ x: null })` to *delete* a top-level key (which only worked accidentally as part of the #1/#3 fix), that now stores `null` instead. Deleting a top-level key was never supported by the type-level contract of component state — top-level keys come from `defaultState` — so this aligns runtime behaviour with the intended schema.
- **Wire format is unchanged**: the delta still carries `null` both for "set to null" (top-level) and for "delete this key" (nested). The depth information is recovered at apply-time on the client, matching the server's `deepAssign`.
- Two of the updated existing tests had `null` deletion asserts at the root — they now assert the corrected behaviour and I added a comment explaining why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)