### PR TITLE
fix(protocol): fail-loud framing, telemetry, ordering, strict codec (fixes #7)

### DIFF
--- a/packages/core/src/__tests__/transport/protocol-codec.test.ts
+++ b/packages/core/src/__tests__/transport/protocol-codec.test.ts
@@ -1,0 +1,372 @@
+// Regression tests for issue #7: protocol, codec, framing, batching.
+//
+// Promoted from __tests__/bug-hunt/protocol-codec.test.ts after the fixes.
+// Each hypothesis is now asserted in its post-fix form.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ComponentStateManager } from '../../component/managers/ComponentStateManager'
+import {
+  queueWsMessage,
+  sendBinaryImmediate,
+  getBatcherStats,
+  resetBatcherStats,
+} from '../../transport/WsSendBatcher'
+import {
+  msgpackCodec,
+  buildRoomFrame,
+  buildRoomFrameTail,
+  parseRoomFrame,
+  prependMemberHeader,
+  BINARY_ROOM_EVENT,
+} from '../../rooms/RoomCodec'
+import { ComponentMessaging } from '../../component/managers/ComponentMessaging'
+
+// Keep the logger quiet so expected warnings do not pollute the test output.
+vi.mock('../../debug/LiveLogger', async () => {
+  const actual = await vi.importActual<any>('../../debug/LiveLogger')
+  return {
+    ...actual,
+    liveLog: vi.fn(),
+    liveWarn: vi.fn(),
+  }
+})
+
+function mockWs() {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: 1,
+    data: {} as any,
+    remoteAddress: '127.0.0.1',
+  } as any
+}
+
+function utf8Len(s: string): number {
+  return new TextEncoder().encode(s).length
+}
+
+beforeEach(() => {
+  resetBatcherStats()
+  vi.clearAllMocks()
+})
+
+// ===========================================================================
+// fixes #7 H1 — componentId > 255 bytes in sendBinaryDelta throws loudly
+// ===========================================================================
+describe('fixes #7 H1: oversized componentId in sendBinaryDelta', () => {
+  it('throws instead of silently truncating the u8 length prefix', () => {
+    const ws = mockWs()
+    const longId = 'live-' + 'A'.repeat(300)
+    expect(utf8Len(longId)).toBeGreaterThan(255)
+
+    const sm = new ComponentStateManager<{ x: number }>({
+      componentId: longId,
+      initialState: { x: 0 },
+      ws,
+      emitFn: () => {},
+      onStateChangeFn: () => {},
+    })
+
+    expect(() =>
+      sm.sendBinaryDelta({ x: 1 }, (d) => new TextEncoder().encode(JSON.stringify(d)))
+    ).toThrow(/exceeds the 255-byte limit/)
+    expect(ws.send).not.toHaveBeenCalled()
+  })
+
+  it('normal-sized componentId still works', () => {
+    const ws = mockWs()
+    const sm = new ComponentStateManager<{ x: number }>({
+      componentId: 'live-12345',
+      initialState: { x: 0 },
+      ws,
+      emitFn: () => {},
+      onStateChangeFn: () => {},
+    })
+
+    sm.sendBinaryDelta({ x: 1 }, (d) => new TextEncoder().encode(JSON.stringify(d)))
+    expect(ws.send).toHaveBeenCalledOnce()
+    const frame = ws.send.mock.calls[0][0] as Uint8Array
+    expect(frame[1]).toBe(utf8Len('live-12345'))
+  })
+})
+
+// ===========================================================================
+// fixes #7 H2 — oversized componentId / roomId / event in RoomCodec
+// ===========================================================================
+describe('fixes #7 H2: oversized frame fields in RoomCodec', () => {
+  it('buildRoomFrame rejects componentId > 255 bytes', () => {
+    const longComp = 'c'.repeat(260)
+    expect(() =>
+      buildRoomFrame(BINARY_ROOM_EVENT, longComp, 'room', 'evt', new Uint8Array())
+    ).toThrow(/componentId.*exceeds the 255-byte limit/)
+  })
+
+  it('buildRoomFrame rejects roomId > 255 bytes', () => {
+    const longRoom = 'r'.repeat(300)
+    expect(() =>
+      buildRoomFrame(BINARY_ROOM_EVENT, 'c', longRoom, 'evt', new Uint8Array())
+    ).toThrow(/roomId.*exceeds the 255-byte limit/)
+  })
+
+  it('buildRoomFrame rejects event > 65535 bytes', () => {
+    const longEvent = 'e'.repeat(70000)
+    expect(() =>
+      buildRoomFrame(BINARY_ROOM_EVENT, 'c', 'r', longEvent, new Uint8Array())
+    ).toThrow(/event.*exceeds the 65535-byte limit/)
+  })
+
+  it('buildRoomFrameTail rejects roomId > 255 bytes', () => {
+    const longRoom = 'r'.repeat(300)
+    expect(() =>
+      buildRoomFrameTail(longRoom, 'evt', new Uint8Array())
+    ).toThrow(/roomId.*exceeds the 255-byte limit/)
+  })
+
+  it('prependMemberHeader rejects componentId > 255 bytes', () => {
+    const longComp = 'c'.repeat(260)
+    expect(() =>
+      prependMemberHeader(BINARY_ROOM_EVENT, longComp, new Uint8Array([1, 2, 3]))
+    ).toThrow(/componentId.*exceeds the 255-byte limit/)
+  })
+
+  it('normal-sized fields roundtrip through buildRoomFrame / parseRoomFrame', () => {
+    const frame = buildRoomFrame(BINARY_ROOM_EVENT, 'comp-1', 'lobby', 'msg', new Uint8Array([9, 8, 7]))
+    const parsed = parseRoomFrame(frame)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.componentId).toBe('comp-1')
+    expect(parsed!.roomId).toBe('lobby')
+    expect(parsed!.event).toBe('msg')
+    expect(Array.from(parsed!.payload)).toEqual([9, 8, 7])
+  })
+})
+
+// ===========================================================================
+// fixes #7 H3 — circular reference in msgpack encoder
+// ===========================================================================
+describe('fixes #7 H3: msgpack encoder detects circular references', () => {
+  it('throws a TypeError with a clear message on a circular object', () => {
+    const obj: any = { a: 1 }
+    obj.self = obj
+
+    expect(() => msgpackCodec.encode(obj)).toThrow(/Circular reference/)
+  })
+
+  it('throws on a circular array too', () => {
+    const arr: any[] = [1, 2]
+    arr.push(arr)
+
+    expect(() => msgpackCodec.encode(arr)).toThrow(/Circular reference/)
+  })
+
+  it('disjoint references to the same sub-object are NOT flagged as circular', () => {
+    // A shared plain sub-object that appears under two different keys is
+    // not a cycle — it is a DAG. The seen-set is removed on the way up.
+    const shared = { x: 1 }
+    const obj = { a: shared, b: shared }
+    expect(() => msgpackCodec.encode(obj)).not.toThrow()
+    const decoded = msgpackCodec.decode(msgpackCodec.encode(obj)) as any
+    expect(decoded.a).toEqual({ x: 1 })
+    expect(decoded.b).toEqual({ x: 1 })
+  })
+})
+
+// ===========================================================================
+// fixes #7 H4 — WsSendBatcher reports serialization failures
+// ===========================================================================
+describe('fixes #7 H4: WsSendBatcher surfaces serialization errors', () => {
+  it('circular payload increments droppedSerializationError', async () => {
+    const ws = mockWs()
+    const circular: any = { foo: 'bar' }
+    circular.self = circular
+
+    queueWsMessage(ws, {
+      type: 'STATE_DELTA',
+      componentId: 'c1',
+      payload: circular,
+      timestamp: Date.now(),
+    })
+
+    await new Promise((r) => queueMicrotask(() => r(undefined)))
+
+    expect(ws.send).not.toHaveBeenCalled()
+    expect(getBatcherStats().droppedSerializationError).toBeGreaterThan(0)
+  })
+})
+
+// ===========================================================================
+// fixes #7 H5/H6 — WS closed drops are counted
+// ===========================================================================
+describe('fixes #7 H5/H6: closed-ws drops are counted', () => {
+  it('queueWsMessage on a closed ws increments droppedClosed and does not send', () => {
+    const ws = mockWs()
+    ws.readyState = 3 // CLOSED
+    queueWsMessage(ws, {
+      type: 'STATE_DELTA',
+      componentId: 'c1',
+      payload: { delta: { x: 1 } },
+      timestamp: Date.now(),
+    })
+    expect(ws.send).not.toHaveBeenCalled()
+    expect(getBatcherStats().droppedClosed).toBeGreaterThan(0)
+  })
+
+  it('ws closed between queue and flush counts all pending messages as closed', async () => {
+    const ws = mockWs()
+    queueWsMessage(ws, {
+      type: 'STATE_DELTA',
+      componentId: 'c1',
+      payload: { delta: { x: 1 } },
+      timestamp: Date.now(),
+    })
+    queueWsMessage(ws, {
+      type: 'STATE_DELTA',
+      componentId: 'c1',
+      payload: { delta: { y: 2 } },
+      timestamp: Date.now(),
+    })
+    // Simulate ws closing before the microtask flush
+    ws.readyState = 3
+    await new Promise((r) => queueMicrotask(() => r(undefined)))
+    expect(ws.send).not.toHaveBeenCalled()
+    expect(getBatcherStats().droppedClosed).toBeGreaterThanOrEqual(2)
+  })
+
+  it('sendBinaryImmediate on closed ws counts the drop', () => {
+    const ws = mockWs()
+    ws.readyState = 3
+    sendBinaryImmediate(ws, new Uint8Array([1, 2, 3]))
+    expect(ws.send).not.toHaveBeenCalled()
+    expect(getBatcherStats().droppedClosed).toBeGreaterThan(0)
+  })
+})
+
+// ===========================================================================
+// fixes #7 H7 — backpressure drops are counted and warned (once)
+// ===========================================================================
+describe('fixes #7 H7: backpressure telemetry', () => {
+  it('queue overflow increments droppedBackpressure', async () => {
+    const ws = mockWs()
+    // Push more than MAX_QUEUE_SIZE (1000) messages — 100 should be dropped.
+    for (let i = 0; i < 1100; i++) {
+      queueWsMessage(ws, {
+        type: 'CUSTOM',
+        componentId: `c${i}`,
+        payload: { i },
+        timestamp: Date.now(),
+      })
+    }
+    await new Promise((r) => queueMicrotask(() => r(undefined)))
+
+    expect(getBatcherStats().droppedBackpressure).toBeGreaterThanOrEqual(100)
+  })
+})
+
+// ===========================================================================
+// fixes #7 H8 — binary vs batched ordering is preserved
+// ===========================================================================
+describe('fixes #7 H8: sendBinaryImmediate flushes the queue first', () => {
+  it('JSON enqueued before a binary immediate lands on the wire first', async () => {
+    const ws = mockWs()
+
+    queueWsMessage(ws, {
+      type: 'STATE_DELTA',
+      componentId: 'c1',
+      payload: { delta: { x: 1 } },
+      timestamp: Date.now(),
+    })
+
+    sendBinaryImmediate(ws, new Uint8Array([0x01, 0x02]))
+
+    // Both should have happened synchronously in order: JSON then binary.
+    expect(ws.send.mock.calls.length).toBe(2)
+    const first = ws.send.mock.calls[0][0]
+    const second = ws.send.mock.calls[1][0]
+    expect(typeof first).toBe('string') // JSON
+    expect(second).toBeInstanceOf(Uint8Array) // Binary
+  })
+})
+
+// ===========================================================================
+// fixes #7 H11 — msgpack decode rejects truncated input
+// ===========================================================================
+describe('fixes #7 H11: msgpack decode rejects truncated input', () => {
+  it('throws RangeError on a truncated encoded buffer', () => {
+    const full = msgpackCodec.encode({ key: 'longvalue-longvalue-longvalue', num: 12345 }) as Uint8Array
+    const truncated = full.slice(0, full.length - 5)
+
+    expect(() => msgpackCodec.decode(truncated)).toThrow(RangeError)
+  })
+
+  it('throws on a buffer that cuts in the middle of a string length field', () => {
+    // A str16 header is 3 bytes: [0xda, lenHi, lenLo]. Truncate after 0xda.
+    const partial = new Uint8Array([0xda])
+    expect(() => msgpackCodec.decode(partial)).toThrow(RangeError)
+  })
+
+  it('does not crash on an empty buffer — throws cleanly', () => {
+    expect(() => msgpackCodec.decode(new Uint8Array(0))).toThrow(RangeError)
+  })
+})
+
+// ===========================================================================
+// fixes #7 H12 — msgpack encoder rejects unsupported types
+// ===========================================================================
+describe('fixes #7 H12: msgpack encoder rejects unsupported types', () => {
+  it('throws on BigInt', () => {
+    expect(() => msgpackCodec.encode({ big: 123n })).toThrow(/BigInt/)
+  })
+
+  it('throws on Date', () => {
+    expect(() => msgpackCodec.encode({ d: new Date(0) })).toThrow(/Date/)
+  })
+
+  it('throws on Map', () => {
+    expect(() => msgpackCodec.encode({ m: new Map([['a', 1]]) })).toThrow(/Map/)
+  })
+
+  it('throws on Set', () => {
+    expect(() => msgpackCodec.encode({ s: new Set([1]) })).toThrow(/Set/)
+  })
+
+  it('throws on RegExp', () => {
+    expect(() => msgpackCodec.encode({ r: /abc/ })).toThrow(/RegExp/)
+  })
+
+  it('throws on Symbol', () => {
+    expect(() => msgpackCodec.encode({ s: Symbol('x') })).toThrow(/Symbol/)
+  })
+
+  it('throws on Function', () => {
+    expect(() => msgpackCodec.encode({ f: () => 1 })).toThrow(/Function/)
+  })
+})
+
+// ===========================================================================
+// H9 — documented limitation: emit() accepts any string as type
+// ===========================================================================
+describe('documented limitation H9: ComponentMessaging.emit does not validate the type string', () => {
+  // There is no runtime whitelist of message types in emit(). The union
+  // type `LiveMessage['type']` is TypeScript-only. Adding a runtime gate
+  // is low-value (no security impact) and would couple the transport to
+  // the protocol schema. Kept as a pinned test so any future change is
+  // an explicit decision.
+  it('emit accepts an arbitrary type string and the batcher sends it', async () => {
+    const ws = mockWs()
+    const messaging = new ComponentMessaging({
+      componentId: 'c1',
+      ws,
+      getUserId: () => undefined,
+      getRoom: () => undefined,
+      getBroadcastToRoom: () => () => {},
+      getEmitOverride: () => null,
+    })
+
+    messaging.emit('TOTALLY_FAKE_TYPE_XYZ' as any, { hello: 'world' })
+    await new Promise((r) => queueMicrotask(() => r(undefined)))
+
+    expect(ws.send).toHaveBeenCalled()
+    const payload = JSON.parse(ws.send.mock.calls[0][0])
+    const msg = Array.isArray(payload) ? payload[0] : payload
+    expect(msg.type).toBe('TOTALLY_FAKE_TYPE_XYZ')
+  })
+})

--- a/packages/core/src/component/managers/ComponentStateManager.ts
+++ b/packages/core/src/component/managers/ComponentStateManager.ts
@@ -146,6 +146,19 @@ export class ComponentStateManager<TState = ComponentState> {
 
     if (!this._idBytes) {
       this._idBytes = new TextEncoder().encode(this.componentId)
+      // Fixes #7 H1: the binary frame length prefix is a u8, so any id
+      // longer than 255 bytes would silently wrap and corrupt the wire
+      // (the client would read `idBytes.length & 0xff` bytes of id and
+      // treat the rest as payload). Framework-generated ids are ~41 bytes,
+      // so this is only reachable via custom ids — we fail loud instead.
+      if (this._idBytes.length > 255) {
+        this._idBytes = null
+        throw new Error(
+          `[ComponentStateManager] componentId is ${new TextEncoder().encode(this.componentId).length} bytes after UTF-8 encoding, ` +
+          `which exceeds the 255-byte limit of the binary frame length prefix. ` +
+          `Use a shorter id (framework-generated ids are ~41 bytes).`
+        )
+      }
     }
     const idBytes = this._idBytes
     const frame = new Uint8Array(1 + 1 + idBytes.length + payload.length)

--- a/packages/core/src/rooms/RoomCodec.ts
+++ b/packages/core/src/rooms/RoomCodec.ts
@@ -36,7 +36,13 @@ const decoder = new TextDecoder()
 
 function msgpackEncode(value: unknown): Uint8Array {
   const parts: Uint8Array[] = []
-  encode(value, parts)
+  // `seen` tracks object/array references already on the current path to
+  // detect circular references (fixes #7 H3). Without this, a circular
+  // value would recurse until RangeError, and callers would either see a
+  // cryptic stack overflow or — worse — a silently swallowed error in the
+  // batcher.
+  const seen = new Set<object>()
+  encode(value, parts, seen)
   // Merge parts into a single buffer
   let totalLen = 0
   for (const p of parts) totalLen += p.length
@@ -49,7 +55,7 @@ function msgpackEncode(value: unknown): Uint8Array {
   return result
 }
 
-function encode(value: unknown, parts: Uint8Array[]): void {
+function encode(value: unknown, parts: Uint8Array[], seen: Set<object>): void {
   if (value === null || value === undefined) {
     parts.push(new Uint8Array([0xc0])) // nil
     return
@@ -103,6 +109,10 @@ function encode(value: unknown, parts: Uint8Array[]): void {
   }
 
   if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      throw new TypeError('[msgpackEncode] Circular reference detected while encoding array')
+    }
+    seen.add(value)
     const len = value.length
     if (len < 16) {
       parts.push(new Uint8Array([0x90 | len]))
@@ -112,12 +122,36 @@ function encode(value: unknown, parts: Uint8Array[]): void {
       parts.push(new Uint8Array([0xdd, (len >> 24) & 0xff, (len >> 16) & 0xff, (len >> 8) & 0xff, len & 0xff]))
     }
     for (const item of value) {
-      encode(item, parts)
+      encode(item, parts, seen)
     }
+    seen.delete(value)
     return
   }
 
   if (typeof value === 'object') {
+    // Fixes #7 H12: reject unsupported non-plain object types explicitly
+    // instead of silently encoding them as empty maps (Date) or nil
+    // (BigInt/Symbol/Function land here too — well, BigInt does not, but
+    // RegExp/Map/Set/Date do). This used to produce silent data loss.
+    if (value instanceof Date) {
+      throw new TypeError(
+        '[msgpackEncode] Date values are not supported in room state. ' +
+        'Store timestamps as numbers (e.g. Date.now()) instead.'
+      )
+    }
+    if (value instanceof Map || value instanceof Set) {
+      throw new TypeError(
+        `[msgpackEncode] ${value.constructor.name} values are not supported in room state. ` +
+        'Convert to a plain object/array before calling setState.'
+      )
+    }
+    if (value instanceof RegExp) {
+      throw new TypeError('[msgpackEncode] RegExp values are not supported in room state.')
+    }
+    if (seen.has(value as object)) {
+      throw new TypeError('[msgpackEncode] Circular reference detected while encoding object')
+    }
+    seen.add(value as object)
     const keys = Object.keys(value as Record<string, unknown>)
     const len = keys.length
     if (len < 16) {
@@ -128,14 +162,31 @@ function encode(value: unknown, parts: Uint8Array[]): void {
       parts.push(new Uint8Array([0xdf, (len >> 24) & 0xff, (len >> 16) & 0xff, (len >> 8) & 0xff, len & 0xff]))
     }
     for (const key of keys) {
-      encode(key, parts)
-      encode((value as Record<string, unknown>)[key], parts)
+      encode(key, parts, seen)
+      encode((value as Record<string, unknown>)[key], parts, seen)
     }
+    seen.delete(value as object)
     return
   }
 
-  // Fallback: encode as null
-  parts.push(new Uint8Array([0xc0]))
+  // Fixes #7 H12: any remaining non-plain type (BigInt, Symbol, Function)
+  // used to be silently encoded as nil — a form of data loss. Throw loudly.
+  if (typeof value === 'bigint') {
+    throw new TypeError(
+      '[msgpackEncode] BigInt values are not supported. ' +
+      'Convert to string or number before calling setState.'
+    )
+  }
+  if (typeof value === 'symbol') {
+    throw new TypeError('[msgpackEncode] Symbol values are not supported in room state.')
+  }
+  if (typeof value === 'function') {
+    throw new TypeError('[msgpackEncode] Function values are not supported in room state.')
+  }
+
+  // Unreachable in practice — all JS types are handled above. If we ever
+  // get here, surface it loudly instead of silently writing nil.
+  throw new TypeError(`[msgpackEncode] Unsupported value of type ${typeof value}`)
 }
 
 function encodeInt(value: number, parts: Uint8Array[]): void {
@@ -185,8 +236,23 @@ function msgpackDecode(buf: Uint8Array): unknown {
   return result.value
 }
 
+/**
+ * Assert that `buf` has at least `need` more bytes starting at `offset`.
+ * Fixes #7 H11: before, an underrun would silently return `{ value: null }`
+ * and keep decoding, so a truncated frame produced a corrupted object
+ * indistinguishable from a legitimate null. We throw instead.
+ */
+function needBytes(buf: Uint8Array, offset: number, need: number, type: string): void {
+  if (offset + need > buf.length) {
+    throw new RangeError(
+      `[msgpackDecode] Truncated input: ${type} at offset ${offset} needs ${need} more bytes, ` +
+      `buffer has ${buf.length - offset}`
+    )
+  }
+}
+
 function decodeAt(buf: Uint8Array, offset: number): { value: unknown; offset: number } {
-  if (offset >= buf.length) return { value: null, offset }
+  needBytes(buf, offset, 1, 'type byte')
 
   const byte = buf[offset]
   const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength)
@@ -203,6 +269,7 @@ function decodeAt(buf: Uint8Array, offset: number): { value: unknown; offset: nu
   // Fixstr (0xa0 - 0xbf)
   if (byte >= 0xa0 && byte <= 0xbf) {
     const len = byte & 0x1f
+    needBytes(buf, offset + 1, len, 'fixstr')
     const str = decoder.decode(buf.subarray(offset + 1, offset + 1 + len))
     return { value: str, offset: offset + 1 + len }
   }
@@ -220,66 +287,100 @@ function decodeAt(buf: Uint8Array, offset: number): { value: unknown; offset: nu
 
     // bin 8
     case 0xc4: {
+      needBytes(buf, offset + 1, 1, 'bin8 length')
       const len = buf[offset + 1]
+      needBytes(buf, offset + 2, len, 'bin8 data')
       return { value: buf.slice(offset + 2, offset + 2 + len), offset: offset + 2 + len }
     }
     // bin 16
     case 0xc5: {
+      needBytes(buf, offset + 1, 2, 'bin16 length')
       const len = view.getUint16(offset + 1, false)
+      needBytes(buf, offset + 3, len, 'bin16 data')
       return { value: buf.slice(offset + 3, offset + 3 + len), offset: offset + 3 + len }
     }
     // bin 32
     case 0xc6: {
+      needBytes(buf, offset + 1, 4, 'bin32 length')
       const len = view.getUint32(offset + 1, false)
+      needBytes(buf, offset + 5, len, 'bin32 data')
       return { value: buf.slice(offset + 5, offset + 5 + len), offset: offset + 5 + len }
     }
 
     // float 64
-    case 0xcb: return { value: view.getFloat64(offset + 1, false), offset: offset + 9 }
+    case 0xcb:
+      needBytes(buf, offset + 1, 8, 'float64')
+      return { value: view.getFloat64(offset + 1, false), offset: offset + 9 }
 
     // uint 8
-    case 0xcc: return { value: buf[offset + 1], offset: offset + 2 }
+    case 0xcc:
+      needBytes(buf, offset + 1, 1, 'uint8')
+      return { value: buf[offset + 1], offset: offset + 2 }
     // uint 16
-    case 0xcd: return { value: view.getUint16(offset + 1, false), offset: offset + 3 }
+    case 0xcd:
+      needBytes(buf, offset + 1, 2, 'uint16')
+      return { value: view.getUint16(offset + 1, false), offset: offset + 3 }
     // uint 32
-    case 0xce: return { value: view.getUint32(offset + 1, false), offset: offset + 5 }
+    case 0xce:
+      needBytes(buf, offset + 1, 4, 'uint32')
+      return { value: view.getUint32(offset + 1, false), offset: offset + 5 }
 
     // int 8
-    case 0xd0: return { value: view.getInt8(offset + 1), offset: offset + 2 }
+    case 0xd0:
+      needBytes(buf, offset + 1, 1, 'int8')
+      return { value: view.getInt8(offset + 1), offset: offset + 2 }
     // int 16
-    case 0xd1: return { value: view.getInt16(offset + 1, false), offset: offset + 3 }
+    case 0xd1:
+      needBytes(buf, offset + 1, 2, 'int16')
+      return { value: view.getInt16(offset + 1, false), offset: offset + 3 }
     // int 32
-    case 0xd2: return { value: view.getInt32(offset + 1, false), offset: offset + 5 }
+    case 0xd2:
+      needBytes(buf, offset + 1, 4, 'int32')
+      return { value: view.getInt32(offset + 1, false), offset: offset + 5 }
 
     // str 8
     case 0xd9: {
+      needBytes(buf, offset + 1, 1, 'str8 length')
       const len = buf[offset + 1]
+      needBytes(buf, offset + 2, len, 'str8 data')
       return { value: decoder.decode(buf.subarray(offset + 2, offset + 2 + len)), offset: offset + 2 + len }
     }
     // str 16
     case 0xda: {
+      needBytes(buf, offset + 1, 2, 'str16 length')
       const len = view.getUint16(offset + 1, false)
+      needBytes(buf, offset + 3, len, 'str16 data')
       return { value: decoder.decode(buf.subarray(offset + 3, offset + 3 + len)), offset: offset + 3 + len }
     }
     // str 32
     case 0xdb: {
+      needBytes(buf, offset + 1, 4, 'str32 length')
       const len = view.getUint32(offset + 1, false)
+      needBytes(buf, offset + 5, len, 'str32 data')
       return { value: decoder.decode(buf.subarray(offset + 5, offset + 5 + len)), offset: offset + 5 + len }
     }
 
     // array 16
-    case 0xdc: return decodeArray(buf, offset + 3, view.getUint16(offset + 1, false))
+    case 0xdc:
+      needBytes(buf, offset + 1, 2, 'array16 count')
+      return decodeArray(buf, offset + 3, view.getUint16(offset + 1, false))
     // array 32
-    case 0xdd: return decodeArray(buf, offset + 5, view.getUint32(offset + 1, false))
+    case 0xdd:
+      needBytes(buf, offset + 1, 4, 'array32 count')
+      return decodeArray(buf, offset + 5, view.getUint32(offset + 1, false))
 
     // map 16
-    case 0xde: return decodeMap(buf, offset + 3, view.getUint16(offset + 1, false))
+    case 0xde:
+      needBytes(buf, offset + 1, 2, 'map16 count')
+      return decodeMap(buf, offset + 3, view.getUint16(offset + 1, false))
     // map 32
-    case 0xdf: return decodeMap(buf, offset + 5, view.getUint32(offset + 1, false))
+    case 0xdf:
+      needBytes(buf, offset + 1, 4, 'map32 count')
+      return decodeMap(buf, offset + 5, view.getUint32(offset + 1, false))
   }
 
-  // Unknown type — skip
-  return { value: null, offset: offset + 1 }
+  // Unknown type — fail loudly instead of silently returning null
+  throw new TypeError(`[msgpackDecode] Unknown type byte 0x${byte.toString(16).padStart(2, '0')} at offset ${offset}`)
 }
 
 function decodeArray(buf: Uint8Array, offset: number, count: number): { value: unknown[]; offset: number } {
@@ -335,6 +436,31 @@ export function resolveCodec(option?: RoomCodecOption): RoomCodec {
 const textEncoder = encoder // reuse
 
 /**
+ * Assert that a UTF-8 byte length fits in a u8 length prefix.
+ * Fixes #7 H2: silent truncation in buildRoomFrame / buildRoomFrameTail /
+ * prependMemberHeader would corrupt the wire and cause parseRoomFrame to
+ * return null (dropping the event silently). We throw loudly instead so
+ * misuse is obvious in development.
+ */
+function assertU8Length(label: string, bytes: Uint8Array): void {
+  if (bytes.length > 255) {
+    throw new Error(
+      `[RoomCodec] ${label} is ${bytes.length} bytes after UTF-8 encoding, ` +
+      `which exceeds the 255-byte limit of the binary frame u8 length prefix.`
+    )
+  }
+}
+
+function assertU16Length(label: string, bytes: Uint8Array): void {
+  if (bytes.length > 0xffff) {
+    throw new Error(
+      `[RoomCodec] ${label} is ${bytes.length} bytes after UTF-8 encoding, ` +
+      `which exceeds the 65535-byte limit of the binary frame u16 length prefix.`
+    )
+  }
+}
+
+/**
  * Build a binary room frame.
  * Format: [frameType:u8][compIdLen:u8][compId:utf8][roomIdLen:u8][roomId:utf8][eventLen:u16BE][event:utf8][payload]
  */
@@ -348,6 +474,10 @@ export function buildRoomFrame(
   const compIdBytes = textEncoder.encode(componentId)
   const roomIdBytes = textEncoder.encode(roomId)
   const eventBytes = textEncoder.encode(event)
+
+  assertU8Length('componentId', compIdBytes)
+  assertU8Length('roomId', roomIdBytes)
+  assertU16Length('event', eventBytes)
 
   const totalLen = 1 + 1 + compIdBytes.length + 1 + roomIdBytes.length + 2 + eventBytes.length + payload.length
   const frame = new Uint8Array(totalLen)
@@ -378,6 +508,9 @@ export function buildRoomFrameTail(
   const roomIdBytes = textEncoder.encode(roomId)
   const eventBytes = textEncoder.encode(event)
 
+  assertU8Length('roomId', roomIdBytes)
+  assertU16Length('event', eventBytes)
+
   const tailLen = 1 + roomIdBytes.length + 2 + eventBytes.length + payload.length
   const tail = new Uint8Array(tailLen)
   let offset = 0
@@ -402,6 +535,7 @@ export function prependMemberHeader(
   tail: Uint8Array,
 ): Uint8Array {
   const compIdBytes = textEncoder.encode(componentId)
+  assertU8Length('componentId', compIdBytes)
   const frame = new Uint8Array(1 + 1 + compIdBytes.length + tail.length)
   frame[0] = frameType
   frame[1] = compIdBytes.length

--- a/packages/core/src/transport/WsSendBatcher.ts
+++ b/packages/core/src/transport/WsSendBatcher.ts
@@ -10,6 +10,7 @@
 
 import type { GenericWebSocket } from './types'
 import { MAX_QUEUE_SIZE } from '../protocol/constants'
+import { liveWarn } from '../debug/LiveLogger'
 
 interface PendingMessage {
   type: string
@@ -32,6 +33,44 @@ const scheduledFlushes = new WeakSet<GenericWebSocket>()
 let pendingWs: GenericWebSocket[] = []
 let globalFlushScheduled = false
 
+// ===== Telemetry (fixes #7) =====
+//
+// Before this was added, the batcher silently dropped messages in three
+// places: backpressure (queue full), ws closed between queue and flush,
+// and serialization errors inside flushAll. Now every drop increments a
+// counter and (for backpressure) emits a one-shot warning per connection
+// so operators notice churn.
+
+interface BatcherStats {
+  /** Messages dropped because the per-connection queue reached MAX_QUEUE_SIZE. */
+  droppedBackpressure: number
+  /** Messages dropped because the WebSocket was closed at flush time. */
+  droppedClosed: number
+  /** Messages dropped because JSON.stringify / ws.send threw during flush. */
+  droppedSerializationError: number
+}
+
+const stats: BatcherStats = {
+  droppedBackpressure: 0,
+  droppedClosed: 0,
+  droppedSerializationError: 0,
+}
+
+/** Connections that have already been warned about backpressure (one-shot). */
+const backpressureWarned = new WeakSet<GenericWebSocket>()
+
+/** Read a snapshot of the batcher's drop counters. */
+export function getBatcherStats(): Readonly<BatcherStats> {
+  return { ...stats }
+}
+
+/** Reset counters (test-only). */
+export function resetBatcherStats(): void {
+  stats.droppedBackpressure = 0
+  stats.droppedClosed = 0
+  stats.droppedSerializationError = 0
+}
+
 function scheduleWs(ws: GenericWebSocket): void {
   if (!scheduledFlushes.has(ws)) {
     scheduledFlushes.add(ws)
@@ -45,11 +84,32 @@ function scheduleWs(ws: GenericWebSocket): void {
 }
 
 /**
+ * Record a backpressure drop and warn once per connection.
+ * Fixes #7 H7: previously the batcher silently `shift()`-ed the oldest
+ * message with no telemetry, so bursty producers caused state drift on
+ * the client with no visible signal.
+ */
+function recordBackpressureDrop(ws: GenericWebSocket): void {
+  stats.droppedBackpressure++
+  if (!backpressureWarned.has(ws)) {
+    backpressureWarned.add(ws)
+    liveWarn('websocket', null,
+      `WsSendBatcher backpressure on connection: per-WS queue reached ${MAX_QUEUE_SIZE} messages. ` +
+      `Oldest messages are being dropped. This warning is one-shot per connection; ` +
+      `check server.getBatcherStats() for running totals.`)
+  }
+}
+
+/**
  * Queue a message to be sent on the next microtask flush.
  * Messages are batched per-WS and sent as a JSON array.
  */
 export function queueWsMessage(ws: GenericWebSocket, message: PendingMessage): void {
-  if (!ws || ws.readyState !== 1) return
+  if (!ws || ws.readyState !== 1) {
+    // Fixes #7 H5/H6: previously this was a silent drop. Count it.
+    if (ws) stats.droppedClosed++
+    return
+  }
 
   let queue = wsQueues.get(ws)
   if (!queue) {
@@ -60,6 +120,7 @@ export function queueWsMessage(ws: GenericWebSocket, message: PendingMessage): v
   // Backpressure: drop oldest messages when queue is full
   if (queue.length >= MAX_QUEUE_SIZE) {
     queue.shift()
+    recordBackpressureDrop(ws)
   }
 
   queue.push(message)
@@ -72,7 +133,10 @@ export function queueWsMessage(ws: GenericWebSocket, message: PendingMessage): v
  * message is sent to many connections.
  */
 export function queuePreSerialized(ws: GenericWebSocket, serialized: string): void {
-  if (!ws || ws.readyState !== 1) return
+  if (!ws || ws.readyState !== 1) {
+    if (ws) stats.droppedClosed++
+    return
+  }
 
   let queue = wsQueues.get(ws)
   if (!queue) {
@@ -83,6 +147,7 @@ export function queuePreSerialized(ws: GenericWebSocket, serialized: string): vo
   // Backpressure: drop oldest messages when queue is full
   if (queue.length >= MAX_QUEUE_SIZE) {
     queue.shift()
+    recordBackpressureDrop(ws)
   }
 
   queue.push(serialized)
@@ -98,64 +163,85 @@ function flushAll(): void {
   pendingWs = []
 
   for (const ws of connections) {
-    scheduledFlushes.delete(ws)
-    const queue = wsQueues.get(ws)
-    if (!queue || queue.length === 0) continue
-    wsQueues.set(ws, [])
+    flushOne(ws)
+  }
+}
 
-    if (ws.readyState !== 1) continue
+/**
+ * Flush a single WS's queue synchronously.
+ *
+ * Exposed so `sendBinaryImmediate` can drain any batched messages BEFORE
+ * writing the binary frame — otherwise the binary frame would overtake
+ * pending JSON state updates on the wire (fixes #7 H8).
+ */
+function flushOne(ws: GenericWebSocket): void {
+  scheduledFlushes.delete(ws)
+  const queue = wsQueues.get(ws)
+  if (!queue || queue.length === 0) return
+  wsQueues.set(ws, [])
 
-    try {
-      if (queue.length === 1) {
-        const item = queue[0]
-        if (typeof item === 'string') {
-          // Pre-serialized — send directly
-          ws.send(item)
-        } else {
-          // Single object message — serialize and send
-          ws.send(JSON.stringify(item))
-        }
+  if (ws.readyState !== 1) {
+    // Fixes #7 H5: previously the messages were silently discarded when
+    // the connection was closed between queue and flush. Count them.
+    stats.droppedClosed += queue.length
+    return
+  }
+
+  try {
+    if (queue.length === 1) {
+      const item = queue[0]
+      if (typeof item === 'string') {
+        // Pre-serialized — send directly
+        ws.send(item)
       } else {
-        // Multiple items — need to build array
-        // Separate pre-serialized strings from objects that need dedup
-        const objects: PendingMessage[] = []
-        const preSerialized: string[] = []
+        // Single object message — serialize and send
+        ws.send(JSON.stringify(item))
+      }
+    } else {
+      // Multiple items — need to build array
+      // Separate pre-serialized strings from objects that need dedup
+      const objects: PendingMessage[] = []
+      const preSerialized: string[] = []
 
-        for (const item of queue) {
-          if (typeof item === 'string') {
-            preSerialized.push(item)
-          } else {
-            objects.push(item)
-          }
-        }
-
-        // Send pre-serialized messages: if only pre-serialized, wrap in array
-        // If mixed, we need to combine them
-        if (objects.length === 0) {
-          // All pre-serialized — build array manually without re-parsing
-          ws.send('[' + preSerialized.join(',') + ']')
-        } else if (preSerialized.length === 0) {
-          // All objects — deduplicate and serialize
-          const deduped = deduplicateDeltas(objects)
-          ws.send(JSON.stringify(deduped))
+      for (const item of queue) {
+        if (typeof item === 'string') {
+          preSerialized.push(item)
         } else {
-          // Mixed — serialize objects, build final string directly (no intermediate arrays)
-          const deduped = deduplicateDeltas(objects)
-          let result = '['
-          for (let i = 0; i < deduped.length; i++) {
-            if (i > 0) result += ','
-            result += JSON.stringify(deduped[i])
-          }
-          for (const ps of preSerialized) {
-            result += ',' + ps
-          }
-          result += ']'
-          ws.send(result)
+          objects.push(item)
         }
       }
-    } catch {
-      // Connection may have closed between queue and flush
+
+      // Send pre-serialized messages: if only pre-serialized, wrap in array
+      // If mixed, we need to combine them
+      if (objects.length === 0) {
+        // All pre-serialized — build array manually without re-parsing
+        ws.send('[' + preSerialized.join(',') + ']')
+      } else if (preSerialized.length === 0) {
+        // All objects — deduplicate and serialize
+        const deduped = deduplicateDeltas(objects)
+        ws.send(JSON.stringify(deduped))
+      } else {
+        // Mixed — serialize objects, build final string directly (no intermediate arrays)
+        const deduped = deduplicateDeltas(objects)
+        let result = '['
+        for (let i = 0; i < deduped.length; i++) {
+          if (i > 0) result += ','
+          result += JSON.stringify(deduped[i])
+        }
+        for (const ps of preSerialized) {
+          result += ',' + ps
+        }
+        result += ']'
+        ws.send(result)
+      }
     }
+  } catch (err: any) {
+    // Fixes #7 H4: previously this catch was empty, so circular refs,
+    // BigInt, getter throws, and post-close ws.send failures were all
+    // swallowed with zero telemetry. Count and log so the cause is visible.
+    stats.droppedSerializationError += queue.length
+    liveWarn('websocket', null,
+      `WsSendBatcher flush failed (${queue.length} message${queue.length === 1 ? '' : 's'} dropped): ${err?.message || err}`)
   }
 }
 
@@ -193,11 +279,29 @@ function deduplicateDeltas(messages: PendingMessage[]): PendingMessage[] {
 
 /**
  * Send a binary message immediately (bypass batching).
- * Binary frames are never batched — they are self-framing.
+ *
+ * Fixes #7 H8: before this fix, `queueWsMessage(A); sendBinaryImmediate(B);`
+ * sent B before A because queued messages waited for the next microtask
+ * while binary writes happened synchronously. That lets a binary state
+ * delta overtake the JSON STATE_UPDATE that establishes the keys it
+ * references, producing garbage on the client. We now flush the per-WS
+ * queue inline before sending the binary frame so ordering matches the
+ * caller's intuition.
  */
 export function sendBinaryImmediate(ws: GenericWebSocket, data: Uint8Array): void {
-  if (ws && ws.readyState === 1) {
+  if (!ws) return
+  if (ws.readyState !== 1) {
+    stats.droppedClosed++
+    return
+  }
+  // Drain any pending batched messages first so they land on the wire
+  // before this binary frame. This preserves caller ordering.
+  flushOne(ws)
+  try {
     ws.send(data)
+  } catch (err: any) {
+    stats.droppedSerializationError++
+    liveWarn('websocket', null, `WsSendBatcher sendBinaryImmediate failed: ${err?.message || err}`)
   }
 }
 
@@ -205,9 +309,21 @@ export function sendBinaryImmediate(ws: GenericWebSocket, data: Uint8Array): voi
  * Send a message immediately (bypass batching).
  * Used for ACTION_RESPONSE and other request-response patterns
  * where the client is awaiting an immediate response.
+ *
+ * Like `sendBinaryImmediate`, this flushes any pending batched messages
+ * first so ordering is preserved.
  */
 export function sendImmediate(ws: GenericWebSocket, data: string): void {
-  if (ws && ws.readyState === 1) {
+  if (!ws) return
+  if (ws.readyState !== 1) {
+    stats.droppedClosed++
+    return
+  }
+  flushOne(ws)
+  try {
     ws.send(data)
+  } catch (err: any) {
+    stats.droppedSerializationError++
+    liveWarn('websocket', null, `WsSendBatcher sendImmediate failed: ${err?.message || err}`)
   }
 }


### PR DESCRIPTION
Closes #7.

## Summary

Ten bugs in the binary/JSON transport surface, all surfaced by the preventive bug-hunt suite. The common pattern was **silent data loss**: u8 length prefixes wrapping without validation, empty catch blocks, silent fallbacks in the msgpack encoder/decoder, and missing telemetry for drop paths. The framework prioritised \"always deliver something\" over \"fail loud and early\" — which is dangerous in a state-replication system.

## Fixes

### Framing (H1, H2)

- **`ComponentStateManager.sendBinaryDelta`**: asserts `componentId` fits in u8. Framework ids are ~41 bytes; the check only fires for custom ids. Throws a clear error instead of silently wrapping `305 & 0xff = 49` and producing corrupt frames.
- **`RoomCodec`**: `buildRoomFrame` / `buildRoomFrameTail` / `prependMemberHeader` now assert u8 on `componentId` / `roomId` and u16 on `event`. Same silent-truncation class as H1.

### Msgpack encoder (H3, H12)

- **Circular reference detection** via a `seen` Set that is removed on the way up, so disjoint references to the same sub-object (a DAG) still encode fine. Previously a cycle produced `RangeError: Maximum call stack size exceeded` which was then swallowed by the batcher.
- **Unsupported types throw loudly** instead of silently encoding as `{}` (Date — because `Object.keys(new Date())` is `[]`) or `nil` (BigInt, Symbol, Function, Map, Set, RegExp). Each error message points the user at the supported alternative.

### Msgpack decoder (H11)

- **Truncation rejection**: every read site now calls `needBytes(buf, offset, need, type)` and throws `RangeError` on underrun. Previously `decodeAt` returned `{ value: null }` on underrun and kept decoding, so a truncated frame produced a corrupt object where truncated fields were indistinguishable from real nulls.
- **Unknown type bytes throw** `TypeError` instead of silently returning `null` + `offset+1`.

### WsSendBatcher (H4, H5, H6, H7, H8)

- **H4 — error telemetry**: `try { ws.send(...) } catch {}` is now `catch (err) { stats.droppedSerializationError += n; liveWarn(...) }`. Circular refs / BigInt / post-close ws.send failures are no longer silenced.
- **H5/H6 — closed-ws drops counted**: `queueWsMessage`, `queuePreSerialized`, `sendBinaryImmediate`, `sendImmediate` all count `droppedClosed` instead of silently returning. The batcher also counts all in-flight messages when the ws closes between queue and flush.
- **H7 — backpressure telemetry**: `MAX_QUEUE_SIZE` overflow used to silently `shift()` the oldest message. Now increments `droppedBackpressure` and emits a **single** `liveWarn` per connection (gated by a `WeakSet`) so operators notice churn without spamming logs.
- **H8 — ordering preserved**: `sendBinaryImmediate` and `sendImmediate` now call a new `flushOne()` helper on the same ws before writing, so JSON enqueued before a binary immediate lands on the wire first. Previously the binary write was synchronous while batched messages waited for the next microtask, so a binary state delta could overtake the JSON `STATE_UPDATE` that established its keys.

### New public API

```ts
import { getBatcherStats, resetBatcherStats } from '@fluxstack/live'

getBatcherStats()
// => { droppedBackpressure: 0, droppedClosed: 0, droppedSerializationError: 0 }
```

`resetBatcherStats()` is test-only.

## Intentionally not fixed

**H9 — `emit()` accepts any string as type** (LOW). The `LiveMessage['type']` union is TypeScript-only; adding a runtime whitelist is low-value (no security impact) and would couple the transport to the protocol schema. Kept as a pinned test under \"documented limitation\" so any future change is an explicit decision.

## Files changed

- `packages/core/src/component/managers/ComponentStateManager.ts` — u8 guard in `sendBinaryDelta`
- `packages/core/src/rooms/RoomCodec.ts` — u8/u16 asserts, seen-set encoder, strict decoder, unsupported-type errors
- `packages/core/src/transport/WsSendBatcher.ts` — telemetry, flushOne helper, ordering fix, non-silent catch

## Regression tests

- `packages/core/src/__tests__/transport/protocol-codec.test.ts` (28 new tests)

## Test plan

- [x] `bunx tsc -p packages/core/tsconfig.json --noEmit` clean
- [x] `tsc` clean in react, elysia, express, fastify
- [x] 28/28 new tests passing
- [x] Full suite: **613/613** passing (2 skipped intentional) on core / react / client / elysia / express / fastify / vue
- [x] `bun run build:core` clean

## Notes for reviewers

- **Behavioural change, possibly breaking**: the msgpack encoder now **throws** on Date / BigInt / Symbol / Function / Map / Set / RegExp. Any consumer that was accidentally relying on the silent-nil fallback needs to convert these to plain values before calling `setState` on a room. This aligns with the documented contract (state must be JSON-serializable) and matches how the JSON codec already behaves.
- **`sendBinaryImmediate` now has observable side effects**: calling it while there are pending batched messages for the same ws now flushes them synchronously. Tests that expected a specific call count on `ws.send` after a mix of `queueWsMessage` + `sendBinaryImmediate` may need to be updated — the intended ordering is preserved now.
- **`getBatcherStats()` counters are process-global**, not per-connection. This matches the implementation (one `WeakMap` for queues, one `WeakSet` for warnings, three module-level counters). If per-connection stats become necessary, we can add a separate API without breaking this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)