### PR TITLE
fix(rooms): opt-in includeSelf on $room proxy emit (fixes #15)

### DIFF
--- a/packages/core/src/__tests__/rooms/proxy-emit-self.test.ts
+++ b/packages/core/src/__tests__/rooms/proxy-emit-self.test.ts
@@ -1,0 +1,314 @@
+// Regression tests for issue #15: asymmetry between LiveRoom.emit() and
+// the ComponentRoomProxy $room().emit() path.
+//
+// Summary of the bug:
+//   - `this.emit(event, data)` from inside a LiveRoom subclass method does
+//     NOT pass any excludeComponentId to LiveRoomManager.emitToRoom, so all
+//     room.on subscribers receive the event.
+//   - `this.$room(X, id).emit(event, data)` from a LiveComponent DOES pass
+//     `self.componentId` as excludeComponentId, silently dropping the event
+//     for the caller's own `room.on` handlers.
+//
+// Fix (Option B from the issue): add an options parameter to the proxy
+// emit — `emit(event, data, { includeSelf: true })` — that opts out of the
+// self-exclusion. Default stays exclude-self for backward compatibility.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { LiveRoomManager } from '../../rooms/LiveRoomManager'
+import { LiveRoom } from '../../rooms/LiveRoom'
+import { RoomRegistry } from '../../rooms/RoomRegistry'
+import { RoomEventBus } from '../../rooms/RoomEventBus'
+import { LiveComponent } from '../../component/LiveComponent'
+import { setLiveComponentContext } from '../../component/context'
+import { createMockWS } from '../helpers'
+
+// Silence the batcher / logger side-effects so we can focus on the event
+// delivery path, not the websocket framing.
+vi.mock('../../transport/WsSendBatcher', () => ({
+  queueWsMessage: vi.fn(),
+  queuePreSerialized: vi.fn(),
+  sendImmediate: vi.fn(),
+  sendBinaryImmediate: vi.fn(),
+}))
+
+vi.mock('../../debug/LiveLogger', () => ({
+  liveLog: vi.fn(),
+  liveWarn: vi.fn(),
+  registerComponentLogging: vi.fn(),
+  unregisterComponentLogging: vi.fn(),
+}))
+
+// ===== Shared fixture =====
+
+type ChatEvents = { 'message:new': { from: string; text: string } }
+
+class ChatRoom extends LiveRoom<{ count: number }, {}, ChatEvents> {
+  static roomName = 'issue15-chat'
+  static defaultState = { count: 0 }
+
+  // Public method that calls this.emit from inside the room class — this
+  // is the path that already works (include-self) and we use it as the
+  // baseline for what the proxy should be able to do too.
+  broadcastFromRoom(msg: ChatEvents['message:new']): number {
+    return this.emit('message:new', msg)
+  }
+}
+
+function setupManager() {
+  const roomEvents = new RoomEventBus()
+  const manager = new LiveRoomManager(roomEvents)
+  const registry = new RoomRegistry()
+  registry.register(ChatRoom as any)
+  manager.roomRegistry = registry
+  // ComponentRoomProxy reads ctx.roomManager / ctx.roomEvents from the
+  // global component context. Install a minimal one for this test.
+  setLiveComponentContext({ roomEvents, roomManager: manager })
+  return { manager, roomEvents }
+}
+
+// ===========================================================================
+// Baseline: LiveRoom.emit from inside a room method delivers to every
+// subscriber, including components that registered their own handler. This
+// is the behaviour the proxy should also be able to produce.
+// ===========================================================================
+describe('baseline: LiveRoom.emit delivers to the invoking component', () => {
+  let cleanup: (() => Promise<void>) | null = null
+  afterEach(async () => {
+    if (cleanup) { await cleanup(); cleanup = null }
+  })
+
+  it('a component that called a room method receives its own emit via room.on', async () => {
+    const { manager } = setupManager()
+
+    class Chat extends LiveComponent<{ received: number }> {
+      static componentName = 'Issue15BaselineChat'
+      static publicActions = [] as const
+      static defaultState = { received: 0 }
+    }
+
+    const ws = createMockWS()
+    const comp = new Chat({}, ws as any)
+
+    // Subscribe to the typed room's 'message:new' via the proxy — this
+    // stores the subscription keyed by the component's id.
+    const handler = vi.fn()
+    const roomHandle = comp.$room(ChatRoom as any, 'r1') as any
+    await roomHandle.join()
+    roomHandle.on('message:new', handler)
+
+    // Grab the underlying LiveRoom instance and emit via the CLASS method.
+    // The class path does not pass excludeComponentId, so the caller's own
+    // subscription MUST be invoked.
+    const roomInstance = manager.getRoomInstance?.('issue15-chat:r1') as ChatRoom
+    expect(roomInstance).toBeTruthy()
+    const notified = roomInstance.broadcastFromRoom({ from: 'server', text: 'hi' })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith({ from: 'server', text: 'hi' })
+    expect(notified).toBeGreaterThanOrEqual(1)
+
+    cleanup = async () => { await manager.cleanupComponent((comp as any).id) }
+  })
+})
+
+// ===========================================================================
+// The bug: proxy emit default — self-exclusion is preserved.
+// This test locks down the CURRENT behaviour as the default after the fix
+// so the Option B rollout stays backward compatible.
+// ===========================================================================
+describe('default proxy emit still excludes the caller (backward compat)', () => {
+  let cleanup: (() => Promise<void>) | null = null
+  afterEach(async () => {
+    if (cleanup) { await cleanup(); cleanup = null }
+  })
+
+  it('this.$room(X, id).emit(event, data) does not fire the caller own room.on', async () => {
+    const { manager } = setupManager()
+
+    class Chat extends LiveComponent<{ received: number }> {
+      static componentName = 'Issue15DefaultChat'
+      static publicActions = [] as const
+      static defaultState = { received: 0 }
+    }
+
+    const ws = createMockWS()
+    const comp = new Chat({}, ws as any)
+
+    const handler = vi.fn()
+    const room = comp.$room(ChatRoom as any, 'r2') as any
+    await room.join()
+    room.on('message:new', handler)
+
+    // Default proxy emit — should exclude self (documented existing behaviour).
+    room.emit('message:new', { from: 'self', text: 'hey' })
+
+    expect(handler).not.toHaveBeenCalled()
+
+    cleanup = async () => { await manager.cleanupComponent((comp as any).id) }
+  })
+
+  it('a second component in the same room still receives the default emit', async () => {
+    const { manager } = setupManager()
+
+    class ChatA extends LiveComponent<{}> {
+      static componentName = 'Issue15DefaultChatA'
+      static publicActions = [] as const
+      static defaultState = {}
+    }
+    class ChatB extends LiveComponent<{}> {
+      static componentName = 'Issue15DefaultChatB'
+      static publicActions = [] as const
+      static defaultState = {}
+    }
+
+    const wsA = createMockWS()
+    const wsB = createMockWS()
+    const a = new ChatA({}, wsA as any)
+    const b = new ChatB({}, wsB as any)
+
+    const handlerA = vi.fn()
+    const handlerB = vi.fn()
+    const roomA = a.$room(ChatRoom as any, 'r3') as any
+    const roomB = b.$room(ChatRoom as any, 'r3') as any
+    await roomA.join()
+    await roomB.join()
+    roomA.on('message:new', handlerA)
+    roomB.on('message:new', handlerB)
+
+    roomA.emit('message:new', { from: 'A', text: 'hi' })
+
+    // Sender excluded, other member receives it.
+    expect(handlerA).not.toHaveBeenCalled()
+    expect(handlerB).toHaveBeenCalledWith({ from: 'A', text: 'hi' })
+
+    cleanup = async () => {
+      await manager.cleanupComponent((a as any).id)
+      await manager.cleanupComponent((b as any).id)
+    }
+  })
+})
+
+// ===========================================================================
+// fixes #15 — opt-in includeSelf
+// ===========================================================================
+describe('fixes #15: proxy emit supports { includeSelf: true }', () => {
+  let cleanup: (() => Promise<void>) | null = null
+  afterEach(async () => {
+    if (cleanup) { await cleanup(); cleanup = null }
+  })
+
+  it('TYPED proxy: $room(RoomClass, id).emit(event, data, { includeSelf: true }) fires the caller own handler', async () => {
+    const { manager } = setupManager()
+
+    class Chat extends LiveComponent<{}> {
+      static componentName = 'Issue15TypedIncludeSelf'
+      static publicActions = [] as const
+      static defaultState = {}
+    }
+
+    const ws = createMockWS()
+    const comp = new Chat({}, ws as any)
+
+    const handler = vi.fn()
+    const room = comp.$room(ChatRoom as any, 'r4') as any
+    await room.join()
+    room.on('message:new', handler)
+
+    room.emit('message:new', { from: 'self', text: 'echo' }, { includeSelf: true })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith({ from: 'self', text: 'echo' })
+
+    cleanup = async () => { await manager.cleanupComponent((comp as any).id) }
+  })
+
+  it('UNTYPED proxy: $room("id").emit(event, data, { includeSelf: true }) fires the caller own handler', async () => {
+    const { manager } = setupManager()
+
+    class Chat extends LiveComponent<{}> {
+      static componentName = 'Issue15UntypedIncludeSelf'
+      static publicActions = [] as const
+      static defaultState = {}
+    }
+
+    const ws = createMockWS()
+    const comp = new Chat({}, ws as any)
+
+    // Pre-create a room instance so the untyped handle has a backing room.
+    await manager.joinRoom((comp as any).id, 'plain:r5', ws as any, { n: 0 })
+
+    const handler = vi.fn()
+    const room = comp.$room('plain:r5')
+    ;(room as any).on('custom:event', handler)
+
+    ;(room as any).emit('custom:event', { payload: 1 }, { includeSelf: true })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith({ payload: 1 })
+
+    cleanup = async () => { await manager.cleanupComponent((comp as any).id) }
+  })
+
+  it('{ includeSelf: false } matches the default (explicit opt-out)', async () => {
+    const { manager } = setupManager()
+
+    class Chat extends LiveComponent<{}> {
+      static componentName = 'Issue15ExplicitOptOut'
+      static publicActions = [] as const
+      static defaultState = {}
+    }
+
+    const ws = createMockWS()
+    const comp = new Chat({}, ws as any)
+
+    const handler = vi.fn()
+    const room = comp.$room(ChatRoom as any, 'r6') as any
+    await room.join()
+    room.on('message:new', handler)
+
+    room.emit('message:new', { from: 'self', text: 'mute me' }, { includeSelf: false })
+
+    expect(handler).not.toHaveBeenCalled()
+
+    cleanup = async () => { await manager.cleanupComponent((comp as any).id) }
+  })
+
+  it('includeSelf does not break delivery to other members in the room', async () => {
+    const { manager } = setupManager()
+
+    class ChatA extends LiveComponent<{}> {
+      static componentName = 'Issue15IncludeSelfWithPeers_A'
+      static publicActions = [] as const
+      static defaultState = {}
+    }
+    class ChatB extends LiveComponent<{}> {
+      static componentName = 'Issue15IncludeSelfWithPeers_B'
+      static publicActions = [] as const
+      static defaultState = {}
+    }
+
+    const wsA = createMockWS()
+    const wsB = createMockWS()
+    const a = new ChatA({}, wsA as any)
+    const b = new ChatB({}, wsB as any)
+
+    const handlerA = vi.fn()
+    const handlerB = vi.fn()
+    const roomA = a.$room(ChatRoom as any, 'r7') as any
+    const roomB = b.$room(ChatRoom as any, 'r7') as any
+    await roomA.join()
+    await roomB.join()
+    roomA.on('message:new', handlerA)
+    roomB.on('message:new', handlerB)
+
+    roomA.emit('message:new', { from: 'A', text: 'broadcast' }, { includeSelf: true })
+
+    expect(handlerA).toHaveBeenCalledWith({ from: 'A', text: 'broadcast' })
+    expect(handlerB).toHaveBeenCalledWith({ from: 'A', text: 'broadcast' })
+
+    cleanup = async () => {
+      await manager.cleanupComponent((a as any).id)
+      await manager.cleanupComponent((b as any).id)
+    }
+  })
+})

--- a/packages/core/src/component/LiveComponent.ts
+++ b/packages/core/src/component/LiveComponent.ts
@@ -13,7 +13,7 @@ import { getLiveComponentContext } from './context'
 import type { GenericWebSocket } from '../transport/types'
 import type { LiveAuthContext, LiveComponentAuth, LiveActionAuthMap } from '../auth/types'
 import { ANONYMOUS_CONTEXT } from '../auth/LiveAuthContext'
-import type { BroadcastMessage, ComponentState, ServerRoomProxy } from '../protocol/messages'
+import type { BroadcastMessage, ComponentState, ServerRoomProxy, RoomEmitOptions } from '../protocol/messages'
 import type { LiveRoom, LiveRoomClass } from '../rooms/LiveRoom'
 
 // Managers
@@ -214,7 +214,13 @@ export abstract class LiveComponent<
       readonly id: string
       join: (payload?: any) => { rejected?: false } | { rejected: true; reason: string }
       leave: () => void
-      emit: R['emit']
+      // Issue #15: extract the room's TEvents map so the proxy emit keeps
+      // the typed event/data pair, then add the optional RoomEmitOptions
+      // third argument. Falling back to LiveRoom<any, any, any> keeps the
+      // generic path permissive for untyped room classes.
+      emit: R extends LiveRoom<any, any, infer E>
+        ? <K extends keyof E & string>(event: K, data: E[K], options?: RoomEmitOptions) => number
+        : (event: string, data: any, options?: RoomEmitOptions) => number
       on: <K extends string>(event: K, handler: (data: any) => void) => () => void
       setState: (updates: Partial<R['state']>) => void
       readonly memberCount: number

--- a/packages/core/src/component/managers/ComponentRoomProxy.ts
+++ b/packages/core/src/component/managers/ComponentRoomProxy.ts
@@ -151,8 +151,13 @@ export class ComponentRoomProxy {
           // onRoomLeave hook is called from LiveComponent
         },
 
-        emit: (event: string, data: any): number => {
-          return self.ctx.roomManager.emitToRoom(roomId, event, data, self.componentId)
+        emit: (event: string, data: any, options?: { includeSelf?: boolean }): number => {
+          // Issue #15: by default exclude the caller so `room.emit` means
+          // "broadcast to everyone else", matching the historical behaviour.
+          // Callers that want their own `room.on` handler to fire too
+          // (e.g. a state-rebuild trigger) can opt in via { includeSelf: true }.
+          const excludeId = options?.includeSelf ? undefined : self.componentId
+          return self.ctx.roomManager.emitToRoom(roomId, event, data, excludeId)
         },
 
         on: (event: string, handler: (data: any) => void): (() => void) => {
@@ -207,9 +212,9 @@ export class ComponentRoomProxy {
         }
       },
       emit: {
-        value: (event: string, data: any) => {
+        value: (event: string, data: any, options?: { includeSelf?: boolean }) => {
           if (!defaultHandle) throw new Error('No default room set')
-          return defaultHandle.emit(event, data)
+          return (defaultHandle as any).emit(event, data, options)
         }
       },
       on: {
@@ -319,9 +324,12 @@ export class ComponentRoomProxy {
         await self.ctx.roomManager.leaveRoom(self.componentId, roomId, 'leave')
       },
 
-      emit: ((event: string, data: any): number => {
-        return self.ctx.roomManager.emitToRoom(roomId, event, data, self.componentId)
-      }) as R['emit'],
+      emit: ((event: string, data: any, options?: { includeSelf?: boolean }): number => {
+        // Issue #15: see the untyped handle above for rationale. The default
+        // still excludes the caller; pass `{ includeSelf: true }` to opt in.
+        const excludeId = options?.includeSelf ? undefined : self.componentId
+        return self.ctx.roomManager.emitToRoom(roomId, event, data, excludeId)
+      }) as any,
 
       on: (event: string, handler: (data: any) => void): (() => void) => {
         const unsubscribe = self.ctx.roomEvents.on(

--- a/packages/core/src/protocol/messages.ts
+++ b/packages/core/src/protocol/messages.ts
@@ -157,12 +157,31 @@ export interface HybridComponentOptions {
 
 // ===== Server Room Handle =====
 
+/**
+ * Options for the proxy-side `emit()` call.
+ *
+ * By default, when a `LiveComponent` emits through `$room(...).emit()`, the
+ * calling component is excluded from receiving its own event. This matches
+ * "broadcast to everyone else" semantics and is the historical behaviour.
+ *
+ * Set `includeSelf: true` to also deliver the event to the caller's own
+ * `room.on()` handlers — useful when using an emit as a state-sync trigger
+ * that should rebuild the caller's local view as well.
+ *
+ * Note: this option only affects the proxy path. `LiveRoom.emit()` called
+ * from inside a room subclass method already delivers to every subscriber.
+ */
+export interface RoomEmitOptions {
+  /** When true, the calling component also receives the event. Default: false. */
+  includeSelf?: boolean
+}
+
 export interface ServerRoomHandle<TState = any, TEvents extends Record<string, any> = Record<string, any>> {
   readonly id: string
   readonly state: TState
   join: (initialState?: TState) => void
   leave: () => void
-  emit: <K extends keyof TEvents>(event: K, data: TEvents[K]) => number
+  emit: <K extends keyof TEvents>(event: K, data: TEvents[K], options?: RoomEmitOptions) => number
   on: <K extends keyof TEvents>(event: K, handler: (data: TEvents[K]) => void) => () => void
   setState: (updates: Partial<TState>) => void
 }
@@ -173,7 +192,7 @@ export interface ServerRoomProxy<TState = any, TEvents extends Record<string, an
   readonly state: TState
   join: (initialState?: TState) => void
   leave: () => void
-  emit: <K extends keyof TEvents>(event: K, data: TEvents[K]) => number
+  emit: <K extends keyof TEvents>(event: K, data: TEvents[K], options?: RoomEmitOptions) => number
   on: <K extends keyof TEvents>(event: K, handler: (data: TEvents[K]) => void) => () => void
   setState: (updates: Partial<TState>) => void
 }


### PR DESCRIPTION
## Summary

- Fixes FluxStackCore/fluxstack-live#15 — `$room(X, id).emit(event, data)` from a `LiveComponent` hardcoded `excludeComponentId = self.componentId`, while `this.emit(event, data)` from inside a `LiveRoom` subclass passed no exclusion. The asymmetry was undocumented and silently dropped events on the caller's own `room.on` handlers.
- Implements **Option B** from the issue: add a third `options` argument to the proxy emit with `{ includeSelf?: boolean }`. Default stays exclude-self (every existing call keeps its current semantics) — callers opt in explicitly when they want to also receive their own emit:

  ```ts
  this.$room(ChatRoom, 'lobby').emit('message:new', msg, { includeSelf: true })
  ```

- `LiveRoom.emit` (the class method called from inside a room) is left alone; its existing include-everyone behaviour is already correct and there is no "self" to exclude.

## Changes

- `packages/core/src/protocol/messages.ts` — new exported `RoomEmitOptions` type; extended `ServerRoomHandle.emit` and `ServerRoomProxy.emit` signatures with the optional third argument.
- `packages/core/src/component/managers/ComponentRoomProxy.ts` — threaded the options through all three proxy emit paths: untyped handle, top-level `proxyFn` emit (which delegates to the default handle), and the typed `\$typedRoom` handle. When `includeSelf` is true, `undefined` is passed as `excludeComponentId` to `LiveRoomManager.emitToRoom`.
- `packages/core/src/component/LiveComponent.ts` — replaced `emit: R['emit']` in the typed handle inline type with an extracted \`TEvents\` variant (`R extends LiveRoom<any, any, infer E>`) that carries the optional `RoomEmitOptions` third parameter, so TypeScript users still get full event-name/event-data typing plus the new options.

## Test plan

- [x] New regression suite at `packages/core/src/__tests__/rooms/proxy-emit-self.test.ts` with 7 cases:
  - **Baseline** — `LiveRoom.emit` from inside a room method delivers to the caller's own `room.on` handler.
  - **Backward compat (2 cases)** — default proxy emit still excludes the caller; peers still receive it.
  - **fixes #15 (4 cases)** — typed proxy with `{ includeSelf: true }` fires the caller; untyped proxy with `{ includeSelf: true }` fires the caller; `{ includeSelf: false }` matches the default (explicit opt-out); `includeSelf` does not break delivery to other members in the same room.
- [x] Bisect validation: reverted only `ComponentRoomProxy.ts` to the `main` version, re-ran the suite — 3 \`fixes #15\` tests fail with \`expected "spy" to be called 1 times, but got 0 times\`. Restored the fix — all 7 pass.
- [x] \`packages/core\` full suite: **600 passed, 1 skipped, 0 failed** (+7 vs. base = the new tests).
- [x] \`bunx tsc -p packages/core/tsconfig.json --noEmit\` clean (the extracted \`TEvents\` conditional keeps the inferred event typing for \`R['emit']\` users).
- [ ] Redis-backed suites not run locally — unaffected by this change (no touch to cluster or room pub/sub paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)