### PR TITLE
feat(core): expose emitWithState() on LiveRoom for atomic setState + emit

### DIFF
--- a/packages/core/src/__tests__/rooms/LiveRoomManager.test.ts
+++ b/packages/core/src/__tests__/rooms/LiveRoomManager.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../debug/LiveLogger', () => ({
 }))
 
 import { queuePreSerialized } from '../../transport/WsSendBatcher'
+import { LiveRoom } from '../../rooms/LiveRoom'
 
 describe('LiveRoomManager', () => {
   let roomEvents: RoomEventBus
@@ -260,6 +261,53 @@ describe('LiveRoomManager', () => {
       const bigData = 'x'.repeat(11 * 1024 * 1024)
       expect(() => manager.setRoomState('big-room', { data: bigData }))
         .toThrow('Room state exceeds maximum size limit')
+    })
+  })
+
+  describe('LiveRoom.emitWithState()', () => {
+    it('calls setRoomState and emitToRoom on the manager in order', () => {
+
+      const calls: string[] = []
+      const mockManager = {
+        setRoomState: vi.fn(() => calls.push('setState')),
+        emitToRoom: vi.fn(() => { calls.push('emit'); return 2 }),
+        getMemberCount: vi.fn().mockReturnValue(2),
+      } as any
+
+      class RaceRoom extends LiveRoom<{ lap: number }, {}, { 'lap:completed': { player: string } }> {
+        static roomName = 'race'
+        static defaultState = { lap: 0 }
+      }
+
+      const room = new RaceRoom('race:1', mockManager)
+      const notified = room.emitWithState('lap:completed', { player: 'p1' }, { lap: 2 })
+
+      expect(mockManager.setRoomState).toHaveBeenCalledWith('race:1', { lap: 2 })
+      expect(mockManager.emitToRoom).toHaveBeenCalledWith('race:1', 'lap:completed', { player: 'p1' })
+      expect(notified).toBe(2)
+      // setState must come before emit
+      expect(calls).toEqual(['setState', 'emit'])
+    })
+
+    it('returns 0 and does not throw when room has no members', () => {
+
+      const mockManager = {
+        setRoomState: vi.fn(),
+        emitToRoom: vi.fn().mockReturnValue(0),
+        getMemberCount: vi.fn().mockReturnValue(0),
+      } as any
+
+      class TestRoom extends LiveRoom<{ x: number }, {}, { moved: { x: number } }> {
+        static roomName = 'test'
+        static defaultState = { x: 0 }
+      }
+
+      const room = new TestRoom('test:1', mockManager)
+      const result = room.emitWithState('moved', { x: 10 }, { x: 10 })
+
+      expect(mockManager.setRoomState).toHaveBeenCalledWith('test:1', { x: 10 })
+      expect(mockManager.emitToRoom).toHaveBeenCalledWith('test:1', 'moved', { x: 10 })
+      expect(result).toBe(0)
     })
   })
 

--- a/packages/core/src/rooms/LiveRoom.ts
+++ b/packages/core/src/rooms/LiveRoom.ts
@@ -119,6 +119,24 @@ export abstract class LiveRoom<
     return this._manager.emitToRoom(this.id, event, data)
   }
 
+  /**
+   * Update public state and emit an event atomically.
+   *
+   * Equivalent to calling `setState(updates)` followed by `emit(event, data)`,
+   * but as a single explicit operation that makes the intent clear: "update
+   * state AND notify clients". Eliminates the common two-call pattern and
+   * prevents bugs where one of the two calls is accidentally omitted.
+   *
+   * Receivers can use the event payload directly without re-reading room state,
+   * which avoids the shared-reference footgun described in issue #19.
+   *
+   * @returns Number of members notified
+   */
+  emitWithState<K extends keyof TEvents & string>(event: K, data: TEvents[K], updates: Partial<TState>): number {
+    this._manager.setRoomState(this.id, updates)
+    return this._manager.emitToRoom(this.id, event, data)
+  }
+
   /** Get current member count */
   get memberCount(): number {
     return this._manager.getMemberCount?.(this.id) ?? 0


### PR DESCRIPTION
## Summary

- Fecha #20: adiciona `LiveRoom.emitWithState(event, data, updates)` como método público
- Elimina o padrão de duas chamadas (`setState` + `emit`) que é verboso e fácil de esquecer
- Receivers podem usar o payload do evento diretamente, sem precisar reler o room state (evita o footgun do #19)
- Delega para `_manager.setRoomState()` + `_manager.emitToRoom()` — infraestrutura já existia internamente via `ComponentRoomProxy`

## Uso

```typescript
// Antes (duas chamadas, fácil de esquecer uma)
movePlayer(userId, position) {
  this.setState({ players: { ...this.state.players, [userId]: { position } } })
  this._manager.emitToRoom(this.id, 'player:moved', { userId, position })
}

// Depois (atômico, explícito)
movePlayer(userId, position) {
  this.emitWithState('player:moved',
    { userId, position },
    { players: { ...this.state.players, [userId]: { position } } }
  )
}
```

## Test plan

- [x] Testa que `setRoomState` é chamado antes de `emitToRoom` (ordem garantida)
- [x] Testa retorno correto (número de membros notificados)
- [x] Testa caso sem membros (retorna 0, não lança)
- [x] 602 testes passando (`bunx vitest run --project core`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)