### PR TITLE
feat(core): warn on shared-reference patch in setState

### DIFF
--- a/packages/core/src/__tests__/component/ComponentStateManager.deepDiff.test.ts
+++ b/packages/core/src/__tests__/component/ComponentStateManager.deepDiff.test.ts
@@ -270,4 +270,76 @@ describe('ComponentStateManager deepDiff', () => {
       expect(deltas.length).toBe(0)
     })
   })
+
+  // ===== Shared Reference Warning (issue #19) =====
+  //
+  // When setState receives a patch where a plain-object value is the SAME
+  // reference as the current state value, deepDiff will short-circuit and
+  // the update will be silently dropped — a common footgun when doing
+  // shallow clones of room state.
+  //
+  // In dev mode (NODE_ENV !== 'production') a warning should be emitted
+  // via liveWarn so the developer notices immediately.
+
+  describe('shared-reference warning (issue #19)', () => {
+    it('warns when patch contains a plain object that is the same reference as current state', async () => {
+      const logger = await import('../../debug/LiveLogger')
+      const warnSpy = vi.spyOn(logger, 'liveWarn').mockImplementation(() => {})
+
+      const ws = createMockWs()
+      const comp = new DeepDiffComponent({}, ws)
+
+      // Grab the SAME reference that's inside state
+      const sharedScores = (comp as any)._stateManager._state.scores
+      comp.setState({ scores: sharedScores })
+      await flush()
+
+      const sharedRefCalls = warnSpy.mock.calls.filter(
+        ([,, msg]) => /shared.*reference|same.*reference|shallow.*clone/i.test(msg ?? '')
+      )
+      expect(sharedRefCalls.length).toBeGreaterThan(0)
+      warnSpy.mockRestore()
+    })
+
+    it('does NOT warn when patch contains a new object (correct usage)', async () => {
+      const logger = await import('../../debug/LiveLogger')
+      const warnSpy = vi.spyOn(logger, 'liveWarn').mockImplementation(() => {})
+
+      const ws = createMockWs()
+      const comp = new DeepDiffComponent({}, ws)
+
+      // New object — correct immutable pattern
+      comp.setState({ scores: { red: 1, blue: 2 } })
+      await flush()
+
+      const sharedRefCalls = warnSpy.mock.calls.filter(
+        ([,, msg]) => /shared.*reference|same.*reference|shallow.*clone/i.test(msg ?? '')
+      )
+      expect(sharedRefCalls).toHaveLength(0)
+      warnSpy.mockRestore()
+    })
+
+    it('does NOT warn in production mode', async () => {
+      const originalEnv = process.env.NODE_ENV
+      process.env.NODE_ENV = 'production'
+
+      const logger = await import('../../debug/LiveLogger')
+      const warnSpy = vi.spyOn(logger, 'liveWarn').mockImplementation(() => {})
+
+      const ws = createMockWs()
+      const comp = new DeepDiffComponent({}, ws)
+
+      const sharedScores = (comp as any)._stateManager._state.scores
+      comp.setState({ scores: sharedScores })
+      await flush()
+
+      const sharedRefCalls = warnSpy.mock.calls.filter(
+        ([,, msg]) => /shared.*reference|same.*reference|shallow.*clone/i.test(msg ?? '')
+      )
+      expect(sharedRefCalls).toHaveLength(0)
+
+      warnSpy.mockRestore()
+      process.env.NODE_ENV = originalEnv
+    })
+  })
 })

--- a/packages/core/src/component/managers/ComponentStateManager.ts
+++ b/packages/core/src/component/managers/ComponentStateManager.ts
@@ -6,6 +6,7 @@
 import type { GenericWebSocket } from '../../transport/types'
 import type { ComponentState } from '../../protocol/messages'
 import { computeDeepDiff, deepAssign } from '../../utils/deepDiff'
+import { liveWarn } from '../../debug/LiveLogger'
 
 /** Per-class cache for forbidden property names in createDirectStateAccessors */
 const _forbiddenSetCache = new WeakMap<Function, Set<string>>()
@@ -85,6 +86,29 @@ export class ComponentStateManager<TState = ComponentState> {
     let hasChanges: boolean
 
     if (this._deepDiff) {
+      // Dev warning: detect shared references between patch and current state.
+      // A plain object in the patch that is === to the current state value will
+      // cause deepDiff to short-circuit and silently drop the update — a common
+      // footgun when doing shallow clones of room state (issue #19).
+      if (process.env.NODE_ENV !== 'production') {
+        for (const key of Object.keys(newUpdates as object)) {
+          const patchVal = (newUpdates as any)[key]
+          const stateVal = (this._state as any)[key]
+          if (
+            patchVal !== null &&
+            typeof patchVal === 'object' &&
+            !Array.isArray(patchVal) &&
+            Object.getPrototypeOf(patchVal) === Object.prototype &&
+            patchVal === stateVal
+          ) {
+            liveWarn('state', this.componentId,
+              `[${this.componentId}] setState: patch key "${key}" is the same reference as current state. ` +
+              `Nested updates will be silently dropped by deepDiff. ` +
+              `Use a shallow clone ({ ...this.state.${key}, ... }) or deep clone to avoid this. (issue #19)`)
+          }
+        }
+      }
+
       // Deep diff: recursively compare plain objects, reference-compare everything else
       const diff = computeDeepDiff(
         this._state as Record<string, unknown>,


### PR DESCRIPTION
## Summary

- Fecha #19: `setState` agora emite `liveWarn` em dev quando o patch contém um plain object com a mesma referência do state atual
- `deepDiff` usa igualdade de referência como fast-path — update silenciosamente descartado sem aviso nenhum
- O warning aponta a chave problemática e sugere o fix (`{ ...this.state.key, ... }`)
- Zero custo em produção — guardado por `process.env.NODE_ENV !== 'production'`

## Exemplo do warning

```
[MyComponent] setState: patch key "players" is the same reference as current state.
Nested updates will be silently dropped by deepDiff.
Use a shallow clone ({ ...this.state.players, ... }) or deep clone to avoid this. (issue #19)
```

## Test plan

- [x] Avisa quando patch tem referência igual ao state atual
- [x] Não avisa quando patch é um novo objeto (uso correto)
- [x] Não avisa em `NODE_ENV=production`
- [x] 605 testes passando (`bunx vitest run --project core`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)