### PR TITLE
fix: issues #33-#36 + state injection hardening

### DIFF
--- a/__tests__/issue-reproducers.test.ts
+++ b/__tests__/issue-reproducers.test.ts
@@ -1,0 +1,205 @@
+// Reproducers for issues #33, #34, #35, #36 — each test recreates the
+// exact scenario from the GitHub issue and asserts the fix holds.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// ─────────────────────────────────────────────────────────────────────────
+// #33 — stub generator produces invalid JS when defaultState strings
+//       contain '.' or '!'
+// ─────────────────────────────────────────────────────────────────────────
+describe('#33 stub generator: strings with . and !', () => {
+  it('reproduces the LiveTrophyHunt minimal repro end-to-end via extractMeta', async () => {
+    const { mkdtempSync, writeFileSync, rmSync } = await import('fs')
+    const { tmpdir } = await import('os')
+    const { join } = await import('path')
+    const { _internals } = await import('../packages/core/src/build/index')
+
+    const dir = mkdtempSync(join(tmpdir(), 'issue-33-'))
+    try {
+      const file = join(dir, 'LiveTrophyHunt.ts')
+      // EXACT class body from issue #33:
+      writeFileSync(file, `
+        import { LiveComponent } from '@fluxstack/live'
+        export class LiveTrophyHunt extends LiveComponent<typeof LiveTrophyHunt.defaultState> {
+          static componentName = 'LiveTrophyHunt'
+          static defaultState = {
+            status: 'Procure o trofeu pelo mundo. Use as dicas!' as string,
+          }
+          static publicActions = ['move'] as const
+        }
+      `, 'utf-8')
+
+      const metas = _internals.extractMeta(file)
+      expect(metas).toHaveLength(1)
+
+      const stub = _internals.buildStub(metas)
+
+      // BEFORE the fix the stub contained `status: 'Procure o trofeu pelo mundo. Use,`
+      // and was invalid JS. Vite reported:
+      //   "Plugin: vite:import-analysis ... Unterminated string"
+      expect(stub).toContain(`'Procure o trofeu pelo mundo. Use as dicas!'`)
+
+      // The stub must be valid JavaScript that Vite can parse — `new Function`
+      // is the same parser path.
+      const exec = new Function(
+        stub.replace(/^export /gm, '') +
+        '; return LiveTrophyHunt.defaultState',
+      )
+      expect(exec()).toEqual({
+        status: 'Procure o trofeu pelo mundo. Use as dicas!',
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// #34 — LiveComponentsProvider opens duplicate WebSockets under StrictMode
+// ─────────────────────────────────────────────────────────────────────────
+describe('#34 StrictMode double-mount does not open a second socket', () => {
+  it('reuses the pooled connection across mount → cleanup → mount', async () => {
+    const { acquire, release, poolKey, _resetPool } = await import('../packages/react/src/connectionPool')
+    _resetPool()
+    vi.useFakeTimers()
+
+    let openCount = 0
+    class FakeConn {
+      constructor() { openCount++ /* this is the "WS handshake" */ }
+      disconnect() {}
+    }
+
+    // Exact StrictMode sequence: effect runs, cleanup runs, effect runs.
+    const key = poolKey({ url: 'ws://localhost:3000/api/live/ws' })
+    const c1 = acquire(key, () => new FakeConn() as any)
+    release(key)                                        // cleanup
+    const c2 = acquire(key, () => new FakeConn() as any) // remount
+
+    // The issue says: "Server log: GET /api/live/ws -> 200 (twice)".
+    // With the fix there must be exactly ONE handshake.
+    expect(openCount).toBe(1)
+    expect(c2).toBe(c1)
+    // And no orphan socket is left after the real unmount:
+    release(key)
+    vi.advanceTimersByTime(100)
+    vi.useRealTimers()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// #35 — actions throw 'Not connected' between $connected=true and $status='synced'
+// ─────────────────────────────────────────────────────────────────────────
+describe('#35 the "$connected=true but mounting" window now has a proper signal', () => {
+  it('isReady is false in the exact failure window from the issue', async () => {
+    const { isReady, computeStatus, notReadyError } = await import('../packages/react/src/hooks/readiness')
+
+    // The issue's symptom log was: `{connected: true, playerId: ""}` →
+    // "register failed Error: Not connected". Translated:
+    //   connected=true, componentId=null (mount RPC in flight)
+    const window = {
+      connected: true,
+      rehydrating: false,
+      loading: false,
+      error: null,
+      componentId: null,
+    }
+    expect(computeStatus(window)).toBe('mounting')
+    expect(isReady(window)).toBe(false)
+
+    // After mount the proxy flips to synced, and isReady is true:
+    expect(isReady({ ...window, componentId: 'comp-1' })).toBe(true)
+
+    // The new error message is informative — it does NOT say "Not connected"
+    // in this case, because the WebSocket IS connected.
+    const err = notReadyError('move', 'LiveTrophyHunt', window)
+    expect(err.message).not.toMatch(/^Error: Not connected$/)
+    expect(err.message).toContain('not mounted')
+    expect(err.message).toContain('$ready')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// #36 — RoomLeaveContext lacks identity to clean up players keyed by app id
+// ─────────────────────────────────────────────────────────────────────────
+describe('#36 onLeave can clean state keyed by an app-specific player id', () => {
+  beforeEach(() => { vi.resetModules() })
+
+  it('reproduces TrophyRoom scenario and removes the player entry on abrupt disconnect', async () => {
+    // Mock the batcher + logger BEFORE importing the manager (mirrors the
+    // pattern used in core/__tests__).
+    vi.doMock('../packages/core/src/transport/WsSendBatcher', () => ({
+      queueWsMessage: vi.fn(),
+      queuePreSerialized: vi.fn(),
+      sendImmediate: vi.fn(),
+      sendBinaryImmediate: vi.fn(),
+    }))
+    vi.doMock('../packages/core/src/debug/LiveLogger', () => ({
+      liveLog: vi.fn(),
+      liveWarn: vi.fn(),
+      registerComponentLogging: vi.fn(),
+      unregisterComponentLogging: vi.fn(),
+    }))
+
+    const { LiveRoomManager } = await import('../packages/core/src/rooms/LiveRoomManager')
+    const { LiveRoom } = await import('../packages/core/src/rooms/LiveRoom')
+    const { RoomRegistry } = await import('../packages/core/src/rooms/RoomRegistry')
+    const { RoomEventBus } = await import('../packages/core/src/rooms/RoomEventBus')
+    const { ANONYMOUS_CONTEXT } = await import('../packages/core/src/auth/LiveAuthContext')
+
+    type TrophyPlayer = { id: string; name: string }
+    type TrophyState = { players: Record<string, TrophyPlayer> }
+
+    // The exact class shape from the issue:
+    class TrophyRoom extends LiveRoom<TrophyState> {
+      static roomName = 'trophy'
+      static defaultState: TrophyState = { players: {} }
+
+      onJoin(ctx: any) {
+        // app-specific id (NOT framework componentId)
+        ctx.membership.playerId = ctx.payload.playerId
+        this.state.players[ctx.payload.playerId] = {
+          id: ctx.payload.playerId,
+          name: ctx.payload.name,
+        }
+      }
+
+      onLeave(ctx: any) {
+        // Before #36 this was impossible — onLeave didn't know the playerId.
+        delete this.state.players[ctx.membership.playerId]
+      }
+    }
+
+    const mgr = new LiveRoomManager(new RoomEventBus())
+    const registry = new RoomRegistry()
+    registry.register(TrophyRoom as any)
+    mgr.roomRegistry = registry
+
+    const ws: any = {
+      send: () => {},
+      close: () => {},
+      data: {
+        connectionId: 'ws-1',
+        components: new Map(),
+        subscriptions: new Set(),
+        connectedAt: new Date(),
+        userId: undefined,
+        authContext: ANONYMOUS_CONTEXT,
+      },
+      remoteAddress: '127.0.0.1',
+      readyState: 1,
+    }
+
+    await mgr.joinRoom('comp-1', 'trophy:lobby', ws, undefined, undefined, {
+      payload: { playerId: 'player-abc', name: 'Alice' },
+    })
+
+    const roomState = (mgr as any).rooms.get('trophy:lobby').state as TrophyState
+    expect(roomState.players['player-abc']).toEqual({ id: 'player-abc', name: 'Alice' })
+
+    // Simulate the exact failure mode: tab closed / network drop →
+    // cleanupComponent is what runs.
+    await mgr.cleanupComponent('comp-1')
+
+    expect(roomState.players['player-abc']).toBeUndefined()
+  })
+})

--- a/__tests__/strictmode-webview.ts
+++ b/__tests__/strictmode-webview.ts
@@ -1,0 +1,80 @@
+// Validates issue #34 end-to-end against the running FluxStack dev server.
+//
+// Strategy:
+//   1. Snapshot how many /api/live/ws hits exist in the server log.
+//   2. Open the app N times in headless Bun.WebView (each load triggers
+//      StrictMode's mount → unmount → mount cycle).
+//   3. Count new /api/live/ws hits in the log.
+//
+// Expected: 1 hit per load (was 2 per load before #34 was fixed).
+//
+// The FluxStack dev server must be running and writing to /tmp/fluxstack.log.
+
+import { readFileSync } from "fs"
+
+const LOG = process.env.FLUXSTACK_LOG ?? "/tmp/fluxstack.log"
+const URL = process.env.FLUXSTACK_URL ?? "http://localhost:3000"
+const LOADS = Number(process.env.LOADS ?? "3")
+const PER_LOAD_WAIT_MS = 2500
+
+function countWsHandshakes(): number {
+  try {
+    // Match the GET log line for /api/live/ws (the trailing arrow varies by
+    // log format encoding — anchor on "GET" + path instead).
+    return (readFileSync(LOG, "utf-8").match(/GET\s+\/api\/live\/ws\b/g) || []).length
+  } catch {
+    return 0
+  }
+}
+
+console.log(`Reading log from: ${LOG}`)
+console.log(`Target URL:       ${URL}`)
+console.log(`Page loads:       ${LOADS}\n`)
+
+const before = countWsHandshakes()
+console.log(`Initial /api/live/ws hits in log: ${before}`)
+
+for (let i = 1; i <= LOADS; i++) {
+  console.log(`\n→ Load ${i}/${LOADS}`)
+  try {
+    await using view = new (Bun as any).WebView({
+      width: 800,
+      height: 600,
+      backend: { type: "chrome", stderr: "ignore" },
+    })
+    await view.navigate(URL)
+    await new Promise(r => setTimeout(r, PER_LOAD_WAIT_MS))
+    const title = await view.evaluate("document.title")
+    console.log(`  page title: ${JSON.stringify(title)}`)
+  } catch (err: any) {
+    console.warn(`  webview error (ignored, will infer from log): ${err.message}`)
+  }
+  // Brief gap so the server log flushes between loads.
+  await new Promise(r => setTimeout(r, 500))
+}
+
+await new Promise(r => setTimeout(r, 1000))
+const after = countWsHandshakes()
+const delta = after - before
+
+console.log(`\n=== Result ===`)
+console.log(`/api/live/ws hits before: ${before}`)
+console.log(`/api/live/ws hits after:  ${after}`)
+console.log(`new handshakes:           ${delta}`)
+console.log(`page loads attempted:     ${LOADS}`)
+console.log(`handshakes per load:      ${(delta / LOADS).toFixed(2)}`)
+
+// With the fix: exactly 1 handshake per successful page load.
+// Without the fix (#34): 2 per load.
+// We allow ≤ LOADS because some loads may fail in headless if Chrome is flaky;
+// we fail if we ever see MORE than LOADS (which would mean dedup is broken).
+if (delta > LOADS) {
+  console.log(`\n❌ FAIL — observed ${delta} handshakes for ${LOADS} loads (>1 per load = #34 regression)`)
+  process.exit(1)
+}
+if (delta === 0) {
+  console.log(`\n⚠️  INCONCLUSIVE — no new handshakes seen; webview may have failed to load. Run manually in a browser to confirm.`)
+  process.exit(2)
+}
+console.log(`\n✅ PASS — ${(delta / LOADS).toFixed(2)} handshake per load (#34 fix verified: ≤ 1 per page load)`)
+process.exit(0)

--- a/packages/client/src/__tests__/session-freeze.test.ts
+++ b/packages/client/src/__tests__/session-freeze.test.ts
@@ -1,0 +1,259 @@
+// Client-side session mirror must be frozen so accidental writes
+// (`proxy.$auth.session.plan = 'enterprise'`) cannot silently corrupt
+// the shared reference shared across React subscribers.
+//
+// Mirrors the server-side AuthenticatedContext deep-freeze. Note: this
+// only protects against LOCAL mutation in the browser — it has no
+// security value (the server doesn't trust client state), but it's a
+// correctness/sanity guarantee against bugs.
+//
+// Coverage targets the three places where auth.session is set:
+//   1. CONNECTION_ESTABLISHED handler auto-sending AUTH
+//   2. Standalone AUTH_RESPONSE handler
+//   3. Public authenticate() method (manual re-auth via Provider)
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { LiveConnection } from '../connection'
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSING = 2
+  static readonly CLOSED = 3
+  readyState = 0
+  binaryType = 'arraybuffer'
+  onopen: ((ev?: any) => void) | null = null
+  onclose: ((ev?: any) => void) | null = null
+  onerror: ((ev?: any) => void) | null = null
+  onmessage: ((ev?: any) => void) | null = null
+  send = vi.fn()
+  close = vi.fn(function (this: MockWebSocket) {
+    this.readyState = 3
+    this.onclose?.({ code: 1000, reason: '' })
+  })
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this)
+  }
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = []
+  ;(globalThis as any).WebSocket = MockWebSocket
+})
+
+afterEach(() => {
+  // no fake timers — we use real async with explicit awaits
+})
+
+/** Subscribe to state and capture the latest auth snapshot. */
+function trackAuth(conn: LiveConnection) {
+  const snapshots: Array<{ authenticated: boolean; session: any }> = []
+  conn.onStateChange((s) => {
+    snapshots.push({ authenticated: s.auth.authenticated, session: s.auth.session })
+  })
+  return {
+    last: () => snapshots[snapshots.length - 1],
+    all: () => snapshots,
+  }
+}
+
+describe('client session mirror — deep frozen (#auth)', () => {
+  it('AUTH_RESPONSE session is frozen at the top level', async () => {
+    const conn = new LiveConnection({ url: 'ws://test/ws', autoConnect: true })
+    const auth = trackAuth(conn)
+
+    const ws = MockWebSocket.instances[0]!
+    ws.readyState = 1
+    ws.onopen?.()
+
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: 'AUTH_RESPONSE',
+        payload: {
+          authenticated: true,
+          session: {
+            id: 'usr-1',
+            email: 'a@b.com',
+            plan: 'enterprise',
+            roles: ['admin', 'user'],
+            permissions: ['users.read'],
+            nested: { orgId: 'org-7', tier: 'gold' },
+          },
+        },
+      }),
+    })
+
+    expect(Object.isFrozen(auth.last().session)).toBe(true)
+    conn.destroy()
+  })
+
+  it('nested objects and arrays inside session are also frozen', async () => {
+    const conn = new LiveConnection({ url: 'ws://test/ws', autoConnect: true })
+    const auth = trackAuth(conn)
+
+    const ws = MockWebSocket.instances[0]!
+    ws.readyState = 1
+    ws.onopen?.()
+
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: 'AUTH_RESPONSE',
+        payload: {
+          authenticated: true,
+          session: { id: 'u-1', org: { id: 'org-7', plan: 'enterprise' }, roles: ['admin'] },
+        },
+      }),
+    })
+
+    const s = auth.last().session
+    expect(Object.isFrozen(s.org)).toBe(true)
+    expect(Object.isFrozen(s.roles)).toBe(true)
+    conn.destroy()
+  })
+
+  it('mutating a top-level field throws in strict mode', async () => {
+    const conn = new LiveConnection({ url: 'ws://test/ws', autoConnect: true })
+    const auth = trackAuth(conn)
+
+    const ws = MockWebSocket.instances[0]!
+    ws.readyState = 1
+    ws.onopen?.()
+
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: 'AUTH_RESPONSE',
+        payload: { authenticated: true, session: { id: 'u-1', plan: 'free' } },
+      }),
+    })
+
+    const s = auth.last().session
+    expect(() => { s.plan = 'enterprise-HACKED' }).toThrow()
+    expect(s.plan).toBe('free')
+    conn.destroy()
+  })
+
+  it('pushing to roles array throws', async () => {
+    const conn = new LiveConnection({ url: 'ws://test/ws', autoConnect: true })
+    const auth = trackAuth(conn)
+
+    const ws = MockWebSocket.instances[0]!
+    ws.readyState = 1
+    ws.onopen?.()
+
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: 'AUTH_RESPONSE',
+        payload: { authenticated: true, session: { id: 'u-1', roles: ['user'] } },
+      }),
+    })
+
+    const s = auth.last().session
+    expect(() => { s.roles.push('admin') }).toThrow()
+    expect(s.roles).toEqual(['user'])
+    conn.destroy()
+  })
+
+  it('adding a brand-new field throws', async () => {
+    const conn = new LiveConnection({ url: 'ws://test/ws', autoConnect: true })
+    const auth = trackAuth(conn)
+
+    const ws = MockWebSocket.instances[0]!
+    ws.readyState = 1
+    ws.onopen?.()
+
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: 'AUTH_RESPONSE',
+        payload: { authenticated: true, session: { id: 'u-1' } },
+      }),
+    })
+
+    const s = auth.last().session
+    expect(() => { s.injected = 'BAD' }).toThrow()
+    expect(s.injected).toBeUndefined()
+    conn.destroy()
+  })
+
+  it('null session (logout / failed auth) is fine — no freeze attempted', async () => {
+    const conn = new LiveConnection({ url: 'ws://test/ws', autoConnect: true })
+    const auth = trackAuth(conn)
+
+    const ws = MockWebSocket.instances[0]!
+    ws.readyState = 1
+    ws.onopen?.()
+
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: 'AUTH_RESPONSE',
+        payload: { authenticated: false, session: null },
+      }),
+    })
+
+    expect(auth.last().session).toBeNull()
+    conn.destroy()
+  })
+
+  it('deeply nested object is frozen up to a bounded depth (no infinite loop)', async () => {
+    const conn = new LiveConnection({ url: 'ws://test/ws', autoConnect: true })
+    const auth = trackAuth(conn)
+
+    const ws = MockWebSocket.instances[0]!
+    ws.readyState = 1
+    ws.onopen?.()
+
+    const deep: any = { id: 'u' }
+    let cur = deep
+    for (let i = 0; i < 50; i++) {
+      cur.next = { i }
+      cur = cur.next
+    }
+    ws.onmessage?.({
+      data: JSON.stringify({ type: 'AUTH_RESPONSE', payload: { authenticated: true, session: deep } }),
+    })
+
+    const s = auth.last().session
+    expect(Object.isFrozen(s)).toBe(true)
+    // Walker bounded at depth 8 — anything deeper may still be mutable, but
+    // it must NOT have hung the call:
+    conn.destroy()
+  })
+
+  it('authenticate() public method also freezes the resulting session', async () => {
+    // This is the path Provider's `authenticate()` exposed to apps takes.
+    const conn = new LiveConnection({ url: 'ws://test/ws', autoConnect: true })
+    const auth = trackAuth(conn)
+
+    const ws = MockWebSocket.instances[0]!
+    ws.readyState = 1
+    ws.onopen?.()
+
+    // Trigger conn.authenticate() — it sends a message and awaits the response.
+    const authPromise = conn.authenticate({ token: 'jwt-abc' })
+
+    // Simulate the server replying with the request's requestId.
+    // We need to peek at what was sent to know the requestId.
+    const lastSend = ws.send.mock.calls[ws.send.mock.calls.length - 1]?.[0]
+    expect(typeof lastSend).toBe('string')
+    const reqMsg = JSON.parse(lastSend)
+    const reqId = reqMsg.requestId
+    expect(reqId).toBeTruthy()
+
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: 'AUTH_RESPONSE',
+        requestId: reqId,
+        success: true,
+        payload: { authenticated: true, session: { id: 'u-1', plan: 'pro' } },
+      }),
+    })
+
+    const ok = await authPromise
+    expect(ok).toBe(true)
+
+    const s = auth.last().session
+    expect(Object.isFrozen(s)).toBe(true)
+    expect(() => { s.plan = 'enterprise' }).toThrow()
+    conn.destroy()
+  })
+})

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -6,6 +6,25 @@
 import type { WebSocketMessage, WebSocketResponse } from '@fluxstack/live'
 import { generateId } from './generateId'
 
+/**
+ * Deep-freeze a session mirror so client code cannot mutate fields locally.
+ * The server-side `AuthenticatedContext` is already frozen — this mirrors
+ * that guarantee on the client so accidental writes
+ * (`proxy.$auth.session.plan = 'enterprise'`) throw in strict mode instead
+ * of silently corrupting the shared reference.
+ *
+ * The deep walk is bounded (depth 8) — auth sessions are leaf-ish objects,
+ * not arbitrary graphs, so this is cheap.
+ */
+function deepFreezeSession(s: unknown, depth = 0): unknown {
+  if (s === null || typeof s !== 'object' || depth > 8) return s
+  if (Object.isFrozen(s)) return s
+  for (const key of Object.keys(s as Record<string, unknown>)) {
+    deepFreezeSession((s as Record<string, unknown>)[key], depth + 1)
+  }
+  return Object.freeze(s)
+}
+
 /** Auth credentials to send during WebSocket connection */
 export interface LiveAuthOptions {
   /** JWT or opaque token */
@@ -308,7 +327,10 @@ export class LiveConnection {
             if (payload?.authenticated) {
               this.setState({
                 authenticated: true,
-                auth: { authenticated: true, session: payload.session || null },
+                auth: {
+                  authenticated: true,
+                  session: deepFreezeSession(payload.session ?? null) as Record<string, unknown> | null,
+                },
               })
             }
           })
@@ -324,7 +346,11 @@ export class LiveConnection {
         authenticated,
         auth: {
           authenticated,
-          session: authenticated ? (payload?.session || null) : null,
+          // Deep-freeze the mirror so consumer code cannot mutate locally
+          // (mirrors the server-side AuthenticatedContext.freeze).
+          session: authenticated
+            ? (deepFreezeSession(payload?.session ?? null) as Record<string, unknown> | null)
+            : null,
         },
       })
     }
@@ -502,7 +528,10 @@ export class LiveConnection {
         authenticated: success,
         auth: {
           authenticated: success,
-          session: success ? (payload?.session || null) : null,
+          // Deep-freeze the mirror (see deepFreezeSession at top).
+          session: success
+            ? (deepFreezeSession(payload?.session ?? null) as Record<string, unknown> | null)
+            : null,
         },
       })
       return success

--- a/packages/core/src/__tests__/build/stub-generator-edge.test.ts
+++ b/packages/core/src/__tests__/build/stub-generator-edge.test.ts
@@ -1,0 +1,188 @@
+// Edge-case coverage for the stub generator (issue #33).
+// The base stub-generator.test.ts file covers the headline regression; this
+// suite hunts for additional ways the scan can be tricked.
+
+import { describe, it, expect } from 'vitest'
+import { _internals } from '../../build/index'
+
+const { stripAsCasts, extractDefaultState, buildStub } = _internals
+
+// Helper: assert the stub is valid JS that round-trips to the expected object.
+function evalStub(stub: string): any {
+  // buildStub emits `export class X { static foo = ... }` — wrap to evaluate.
+  const src = stub.replace(/^export /gm, '')
+  const fn = new Function(`${src}; return ({ defaultState: typeof X !== 'undefined' ? X.defaultState : null })`.replace(/X/g, extractClassName(stub)))
+  return fn()
+}
+function extractClassName(stub: string): string {
+  return stub.match(/class (\w+)/)?.[1] ?? 'X'
+}
+
+describe('stripAsCasts — string literal edge cases (#33)', () => {
+  it('preserves a string ending in a backslash before the closing quote', () => {
+    const out = stripAsCasts(`{ s: 'ends with backslash\\\\' as string }`)
+    expect(out).toContain(`'ends with backslash\\\\'`)
+    expect(out).not.toContain(' as string')
+  })
+
+  it('preserves a string containing both kinds of quotes', () => {
+    const out = stripAsCasts(`{ s: 'has "double" inside' as string }`)
+    expect(out).toContain(`'has "double" inside'`)
+    expect(out).not.toContain(' as string')
+  })
+
+  it('preserves a string containing a brace', () => {
+    // Braces inside strings must not trip the cast-end detector.
+    const out = stripAsCasts(`{ s: 'has } inside' as string, n: 1 }`)
+    expect(out).toContain(`'has } inside'`)
+    expect(out).toContain('n: 1')
+    expect(out).not.toContain(' as string')
+  })
+
+  it('preserves a string containing a comma', () => {
+    const out = stripAsCasts(`{ s: 'a, b, c' as string, n: 1 }`)
+    expect(out).toContain(`'a, b, c'`)
+    expect(out).toContain('n: 1')
+  })
+
+  it('preserves a string containing a slash that could look like a comment', () => {
+    const out = stripAsCasts(`{ s: 'a/b//c' as string, t: 'x/*y*/z' as string }`)
+    expect(out).toContain(`'a/b//c'`)
+    expect(out).toContain(`'x/*y*/z'`)
+  })
+
+  it('handles template literal with interpolation that mentions "as"', () => {
+    const out = stripAsCasts('{ s: `prefix ${x as number} suffix as fallback` as string }')
+    // The user-facing text inside the template stays intact:
+    expect(out).toContain('suffix as fallback')
+    // The outer ` as string ` cast is stripped:
+    expect(out).not.toMatch(/`\s*as\s+string\b/)
+  })
+
+  it('handles nested template literals', () => {
+    const out = stripAsCasts('{ s: `outer ${`inner as nested`} end` as string }')
+    expect(out).toContain('inner as nested')
+    expect(out).not.toMatch(/`\s*as\s+string\b/)
+  })
+
+  it('handles multi-line string via escaped newline (template)', () => {
+    const out = stripAsCasts('{ s: `line1\nline2 as token\nline3` as string }')
+    expect(out).toContain('line2 as token')
+  })
+})
+
+describe('stripAsCasts — token-boundary edge cases (#33)', () => {
+  it('does not strip "as" embedded in identifiers (class, was, has, gas)', () => {
+    const out = stripAsCasts(`{ className: 'x', wasReady: true, hasUser: false, gasoline: 1 }`)
+    expect(out).toContain('className')
+    expect(out).toContain('wasReady')
+    expect(out).toContain('hasUser')
+    expect(out).toContain('gasoline')
+  })
+
+  it('strips cast when preceded by closing bracket/paren', () => {
+    const out = stripAsCasts(`{ a: foo() as number, b: arr[0] as string }`)
+    expect(out).not.toContain(' as number')
+    expect(out).not.toContain(' as string')
+    expect(out).toContain('foo()')
+    expect(out).toContain('arr[0]')
+  })
+
+  it('strips chained casts (as A as B)', () => {
+    // Two casts in a row — both should disappear.
+    const out = stripAsCasts(`{ x: 1 as unknown as Foo, y: 2 }`)
+    expect(out).not.toContain(' as ')
+    expect(out).toContain('x: 1')
+    expect(out).toContain('y: 2')
+  })
+})
+
+describe('stripAsCasts — comment edge cases (#33)', () => {
+  it('still strips casts that come after a line comment on the same source', () => {
+    const out = stripAsCasts(`{
+      // a comment mentioning as
+      x: 1 as number,
+      y: 2,
+    }`)
+    expect(out).toContain('// a comment mentioning as')
+    expect(out).not.toContain(' as number')
+    expect(out).toContain('y: 2')
+  })
+
+  it('handles a block comment immediately before a cast', () => {
+    const out = stripAsCasts(`{ x: /* note */ 1 as number, y: 2 }`)
+    expect(out).toContain('/* note */')
+    expect(out).not.toContain(' as number')
+    expect(out).toContain('y: 2')
+  })
+
+  it('does not get confused by `//` inside a string', () => {
+    const out = stripAsCasts(`{ url: 'http://example.com' as string, n: 1 as number }`)
+    expect(out).toContain(`'http://example.com'`)
+    // The cast on n: must still be stripped — the "//" inside the URL must
+    // not have switched us into line-comment mode for the rest of the input.
+    expect(out).not.toMatch(/n:\s*1\s*as\s+number/)
+  })
+})
+
+describe('extractDefaultState — full-object edge cases (#33)', () => {
+  it('handles deeply nested object with strings containing "as"', () => {
+    const body = `
+      static defaultState = {
+        meta: {
+          tagline: 'cool as ice',
+          tips: ['Use as needed', 'eat your veggies'] as string[],
+        },
+        ready: false as boolean,
+      }
+    `
+    const out = extractDefaultState(body)
+    expect(out).toContain(`'cool as ice'`)
+    expect(out).toContain(`'Use as needed'`)
+    expect(out).not.toContain(' as string')
+    expect(out).not.toContain(' as boolean')
+  })
+
+  it('handles TS type annotation on defaultState itself', () => {
+    const body = `
+      static defaultState: Record<string, any> = {
+        s: 'use as a hint',
+        n: 0 as number,
+      }
+    `
+    const out = extractDefaultState(body)
+    expect(out).toContain(`'use as a hint'`)
+    expect(out).not.toContain(' as number')
+  })
+
+  it('returns "{}" when defaultState is missing', () => {
+    expect(extractDefaultState(`class Foo {}`)).toBe('{}')
+  })
+})
+
+describe('buildStub — validity (#33)', () => {
+  it('produces JS that parses for issue #33 minimal reproducer', () => {
+    const stub = buildStub([{
+      className: 'LiveTrophyHunt',
+      componentName: 'LiveTrophyHunt',
+      defaultState: `{ status: 'Procure o trofeu pelo mundo. Use as dicas!' }`,
+      publicActions: `['move']`,
+    }])
+    // Wrap to evaluate without `export`.
+    const src = stub.replace(/^export /gm, '')
+    const fn = new Function(`${src}; return LiveTrophyHunt.defaultState`)
+    const state = fn()
+    expect(state).toEqual({ status: 'Procure o trofeu pelo mundo. Use as dicas!' })
+  })
+
+  it('produces JS that parses for a state object with arrays and nested objects', () => {
+    const stub = buildStub([{
+      className: 'X',
+      componentName: 'X',
+      defaultState: `{ items: [], meta: { tip: 'use as needed' }, ok: false }`,
+      publicActions: '[]',
+    }])
+    const fn = new Function(`${stub.replace(/^export /gm, '')}; return X.defaultState`)
+    expect(fn()).toEqual({ items: [], meta: { tip: 'use as needed' }, ok: false })
+  })
+})

--- a/packages/core/src/__tests__/build/stub-generator.test.ts
+++ b/packages/core/src/__tests__/build/stub-generator.test.ts
@@ -1,0 +1,99 @@
+// Regression tests for the stub generator (issue #33).
+// stripAsCasts must skip string/template literals and comments so it cannot
+// truncate user content like `'Use as dicas!'`.
+
+import { describe, it, expect } from 'vitest'
+import { _internals } from '../../build/index'
+
+const { stripAsCasts, extractDefaultState, buildStub } = _internals
+
+describe('stripAsCasts (issue #33)', () => {
+  it('preserves single-quoted string containing " as "', () => {
+    const out = stripAsCasts(`{ status: 'Use as dicas!' as string }`)
+    expect(out).toContain(`'Use as dicas!'`)
+    expect(out).not.toMatch(/'\s*as\s+string/)
+  })
+
+  it('preserves double-quoted string containing " as "', () => {
+    const out = stripAsCasts(`{ status: "use as a hint" as string }`)
+    expect(out).toContain(`"use as a hint"`)
+    expect(out).not.toMatch(/"\s*as\s+string/)
+  })
+
+  it('preserves backtick template literal containing " as "', () => {
+    const out = stripAsCasts(`{ status: \`use as a hint\` as string }`)
+    expect(out).toContain('`use as a hint`')
+    expect(out).not.toMatch(/`\s*as\s+string/)
+  })
+
+  it('handles escaped quotes inside strings', () => {
+    const out = stripAsCasts(`{ s: 'it\\'s as good' as string }`)
+    expect(out).toContain(`'it\\'s as good'`)
+  })
+
+  it('still strips genuine `as <Type>` casts on arrays and primitives', () => {
+    const out = stripAsCasts(`{ items: [] as string[], ready: false as boolean }`)
+    expect(out).not.toContain(' as string')
+    expect(out).not.toContain(' as boolean')
+    expect(out).toContain('items: []')
+    expect(out).toContain('ready: false')
+  })
+
+  it('strips casts with generics', () => {
+    const out = stripAsCasts(`{ map: {} as Record<string, number> }`)
+    expect(out).not.toContain('Record<string, number>')
+    expect(out).toContain('map: {}')
+  })
+
+  it('does not strip identifiers that merely contain "as" (e.g. "class")', () => {
+    const out = stripAsCasts(`{ className: 'foo', bar: 1 }`)
+    expect(out).toContain(`className: 'foo'`)
+    expect(out).toContain('bar: 1')
+  })
+
+  it('skips line comments containing the word "as"', () => {
+    const out = stripAsCasts(`{
+      // use as a hint
+      n: 1 as number,
+    }`)
+    expect(out).toContain('// use as a hint')
+    expect(out).not.toContain(' as number')
+  })
+
+  it('skips block comments containing the word "as"', () => {
+    const out = stripAsCasts(`{
+      /* use as a hint */
+      n: 1 as number,
+    }`)
+    expect(out).toContain('use as a hint')
+    expect(out).not.toContain(' as number')
+  })
+})
+
+describe('extractDefaultState (issue #33)', () => {
+  it('preserves user strings ending in punctuation', () => {
+    const body = `
+      static defaultState = {
+        status: 'Procure o trofeu pelo mundo. Use as dicas!' as string,
+        count: 0,
+      }
+    `
+    const out = extractDefaultState(body)
+    expect(out).toContain(`'Procure o trofeu pelo mundo. Use as dicas!'`)
+    expect(out).toContain('count: 0')
+  })
+})
+
+describe('buildStub (issue #33)', () => {
+  it('round-trips a defaultState with strings containing "as" into valid JS', () => {
+    const stub = buildStub([{
+      className: 'LiveTrophyHunt',
+      componentName: 'LiveTrophyHunt',
+      defaultState: `{ status: 'Use as dicas!', count: 0 }`,
+      publicActions: '[]',
+    }])
+    // Sanity check: the stub must parse as valid JS.
+    expect(() => new Function(stub.replace(/^export /gm, ''))).not.toThrow()
+    expect(stub).toContain(`'Use as dicas!'`)
+  })
+})

--- a/packages/core/src/__tests__/integration/custom-session-shape.test.ts
+++ b/packages/core/src/__tests__/integration/custom-session-shape.test.ts
@@ -1,0 +1,353 @@
+// End-to-end validation that a developer can define ARBITRARY session shapes
+// (user, bot, IoT device) and have those shapes flow intact through:
+//   1. their own LiveAuthProvider
+//   2. AuthenticatedContext (frozen, generic)
+//   3. LiveComponent.this.$auth.session (reads custom fields)
+//   4. LiveRoom.onJoin/onLeave ctx.session (ditto, even on abrupt disconnect)
+//
+// This is the integration counterpart to the unit tests in
+// LiveRoomManager.session-context.test.ts — it exercises the real
+// LiveAuthManager + AuthenticatedContext, not mocks.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { LiveAuthManager } from '../../auth/LiveAuthManager'
+import { AuthenticatedContext } from '../../auth/LiveAuthContext'
+import { LiveComponent } from '../../component/LiveComponent'
+import { LiveRoom } from '../../rooms/LiveRoom'
+import { LiveRoomManager } from '../../rooms/LiveRoomManager'
+import { RoomRegistry } from '../../rooms/RoomRegistry'
+import { RoomEventBus } from '../../rooms/RoomEventBus'
+import { createMockWS } from '../helpers'
+import type {
+  LiveAuthProvider,
+  LiveAuthCredentials,
+  LiveAuthContext,
+  LiveAuthSession,
+} from '../../auth/types'
+
+vi.mock('../../transport/WsSendBatcher', () => ({
+  queueWsMessage: vi.fn(),
+  queuePreSerialized: vi.fn(),
+  sendImmediate: vi.fn(),
+  sendBinaryImmediate: vi.fn(),
+}))
+vi.mock('../../debug/LiveLogger', () => ({
+  liveLog: vi.fn(),
+  liveWarn: vi.fn(),
+  registerComponentLogging: vi.fn(),
+  unregisterComponentLogging: vi.fn(),
+}))
+
+// ===== Dev defines custom session shapes =====
+
+interface UserSession extends LiveAuthSession {
+  id: string
+  email: string
+  plan: 'free' | 'pro' | 'enterprise'
+  orgId: string
+  roles?: string[]
+}
+
+interface BotSession extends LiveAuthSession {
+  id: string
+  kind: 'bot'
+  model: string
+  ownerOrgId: string
+  allowedActions: string[]
+}
+
+interface DeviceSession extends LiveAuthSession {
+  id: string
+  kind: 'device'
+  deviceType: 'sensor' | 'actuator'
+  location: string
+  firmware: string
+}
+
+// ===== Dev implements a provider that returns whichever session matches the token =====
+
+class MyMixedProvider implements LiveAuthProvider {
+  readonly name = 'mixed'
+
+  async authenticate(creds: LiveAuthCredentials): Promise<LiveAuthContext | null> {
+    const token = creds.token as string
+    if (!token) return null
+
+    if (token === 'user-token') {
+      const s: UserSession = {
+        id: 'usr-1', email: 'alice@example.com', plan: 'enterprise',
+        orgId: 'org-7', roles: ['admin'],
+      }
+      return new AuthenticatedContext(s, token)
+    }
+    if (token === 'bot-token') {
+      const s: BotSession = {
+        id: 'bot-42', kind: 'bot', model: 'claude-opus-4-7',
+        ownerOrgId: 'org-7', allowedActions: ['summarize', 'reply'],
+      }
+      return new AuthenticatedContext(s, token)
+    }
+    if (token === 'device-token') {
+      const s: DeviceSession = {
+        id: 'dev-xyz', kind: 'device', deviceType: 'sensor',
+        location: 'sala-2', firmware: '1.4.0',
+      }
+      return new AuthenticatedContext(s, token)
+    }
+    return null
+  }
+}
+
+// ===== Helpers =====
+
+function makeRoomManager() {
+  const mgr = new LiveRoomManager(new RoomEventBus())
+  const registry = new RoomRegistry()
+  mgr.roomRegistry = registry
+  return { mgr, registry }
+}
+
+let errSpy: ReturnType<typeof vi.spyOn>
+beforeEach(() => { errSpy = vi.spyOn(console, 'error').mockImplementation(() => {}) })
+afterEach(() => { errSpy.mockRestore(); vi.clearAllMocks() })
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('Provider → AuthenticatedContext → session flows', () => {
+  it('LiveAuthManager round-trips a custom UserSession through authenticate()', async () => {
+    const authMgr = new LiveAuthManager()
+    authMgr.register(new MyMixedProvider())
+
+    const ctx = await authMgr.authenticate({ token: 'user-token' })
+    expect(ctx.authenticated).toBe(true)
+
+    const s = ctx.session as UserSession | undefined
+    expect(s?.id).toBe('usr-1')
+    expect(s?.email).toBe('alice@example.com')
+    expect(s?.plan).toBe('enterprise')
+    expect(s?.orgId).toBe('org-7')
+  })
+
+  it('LiveAuthManager round-trips a custom BotSession (different shape)', async () => {
+    const authMgr = new LiveAuthManager()
+    authMgr.register(new MyMixedProvider())
+
+    const ctx = await authMgr.authenticate({ token: 'bot-token' })
+    const s = ctx.session as BotSession | undefined
+    expect(s?.kind).toBe('bot')
+    expect(s?.model).toBe('claude-opus-4-7')
+    expect(s?.allowedActions).toEqual(['summarize', 'reply'])
+  })
+
+  it('LiveAuthManager round-trips a custom DeviceSession (no kind:bot/user)', async () => {
+    const authMgr = new LiveAuthManager()
+    authMgr.register(new MyMixedProvider())
+
+    const ctx = await authMgr.authenticate({ token: 'device-token' })
+    const s = ctx.session as DeviceSession | undefined
+    expect(s?.kind).toBe('device')
+    expect(s?.deviceType).toBe('sensor')
+    expect(s?.location).toBe('sala-2')
+    expect(s?.firmware).toBe('1.4.0')
+  })
+
+  it('AuthenticatedContext freezes the session — custom fields cannot be mutated', async () => {
+    const authMgr = new LiveAuthManager()
+    authMgr.register(new MyMixedProvider())
+
+    const ctx = await authMgr.authenticate({ token: 'user-token' })
+    const s = ctx.session as UserSession | undefined
+
+    // Mutation must fail silently (frozen) or throw — either is acceptable.
+    expect(() => {
+      (s as any).plan = 'free' // privilege downgrade attempt
+    }).toThrow() // strict mode: TypeError
+
+    // The original value is preserved either way:
+    expect((ctx.session as UserSession | undefined)?.plan).toBe('enterprise')
+  })
+
+  it('roles/permissions are also frozen (defense against escalation)', async () => {
+    const authMgr = new LiveAuthManager()
+    authMgr.register(new MyMixedProvider())
+
+    const ctx = await authMgr.authenticate({ token: 'user-token' })
+    expect(() => { (ctx.session?.roles as any).push('superadmin') }).toThrow()
+    expect(ctx.session?.roles).toEqual(['admin'])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('Custom session reaches LiveComponent.this.$auth.session', () => {
+  it('component receives the full custom session shape', async () => {
+    const authMgr = new LiveAuthManager()
+    authMgr.register(new MyMixedProvider())
+    const ctx = await authMgr.authenticate({ token: 'user-token' })
+
+    // Build a component instance with the auth context (mimics what the
+    // framework does during COMPONENT_MOUNT).
+    class BillingPanel extends LiveComponent<{ x: number }> {
+      static componentName = 'BillingPanel'
+      static defaultState = { x: 0 }
+      readPlan() {
+        const s = this.$auth.session as UserSession | undefined
+        return s?.plan
+      }
+    }
+    const comp = new BillingPanel({ x: 0 }, null as any)
+    comp.setAuthContext(ctx)
+
+    expect(comp.readPlan()).toBe('enterprise')
+    expect((comp.$auth.session as UserSession).email).toBe('alice@example.com')
+    expect((comp.$auth.session as UserSession).orgId).toBe('org-7')
+  })
+
+  it('component sees a bot session distinctly from a user session', async () => {
+    const authMgr = new LiveAuthManager()
+    authMgr.register(new MyMixedProvider())
+
+    class GenericComponent extends LiveComponent<{ x: number }> {
+      static componentName = 'X'
+      static defaultState = { x: 0 }
+      whoAmI() {
+        const s = this.$auth.session as UserSession | BotSession | undefined
+        if (!s) return 'anonymous'
+        if ((s as BotSession).kind === 'bot') return `bot:${(s as BotSession).model}`
+        return `user:${(s as UserSession).email}`
+      }
+    }
+
+    const userCtx = await authMgr.authenticate({ token: 'user-token' })
+    const botCtx = await authMgr.authenticate({ token: 'bot-token' })
+
+    const c1 = new GenericComponent({ x: 0 }, null as any)
+    c1.setAuthContext(userCtx)
+    const c2 = new GenericComponent({ x: 0 }, null as any)
+    c2.setAuthContext(botCtx)
+
+    expect(c1.whoAmI()).toBe('user:alice@example.com')
+    expect(c2.whoAmI()).toBe('bot:claude-opus-4-7')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('Custom session reaches LiveRoom onJoin / onLeave', () => {
+  it('a single GameRoom can dispatch on session.kind across user/bot/device', async () => {
+    const authMgr = new LiveAuthManager()
+    authMgr.register(new MyMixedProvider())
+    const { mgr, registry } = makeRoomManager()
+
+    interface GameState {
+      humans: Record<string, { email: string; plan: string }>
+      bots: Record<string, { model: string }>
+      devices: Record<string, { location: string }>
+    }
+
+    class GameRoom extends LiveRoom<GameState> {
+      static roomName = 'game'
+      static defaultState: GameState = { humans: {}, bots: {}, devices: {} }
+      onJoin(ctx: any) {
+        const s = ctx.session as UserSession | BotSession | DeviceSession | undefined
+        if (!s) return
+        if ((s as BotSession).kind === 'bot') {
+          this.state.bots[s.id] = { model: (s as BotSession).model }
+        } else if ((s as DeviceSession).kind === 'device') {
+          this.state.devices[s.id] = { location: (s as DeviceSession).location }
+        } else {
+          const u = s as UserSession
+          this.state.humans[u.id] = { email: u.email, plan: u.plan }
+        }
+      }
+      onLeave(ctx: any) {
+        const s = ctx.session as UserSession | BotSession | DeviceSession | undefined
+        if (!s) return
+        if ((s as BotSession).kind === 'bot') delete this.state.bots[s.id]
+        else if ((s as DeviceSession).kind === 'device') delete this.state.devices[s.id]
+        else delete this.state.humans[s.id]
+      }
+    }
+    registry.register(GameRoom as any)
+
+    const userCtx = await authMgr.authenticate({ token: 'user-token' })
+    const botCtx = await authMgr.authenticate({ token: 'bot-token' })
+    const devCtx = await authMgr.authenticate({ token: 'device-token' })
+
+    const wsUser = createMockWS({ authContext: userCtx, userId: userCtx.session?.id })
+    const wsBot = createMockWS({ authContext: botCtx, userId: botCtx.session?.id })
+    const wsDev = createMockWS({ authContext: devCtx, userId: devCtx.session?.id })
+
+    await mgr.joinRoom('c-user', 'game:r', wsUser)
+    await mgr.joinRoom('c-bot', 'game:r', wsBot)
+    await mgr.joinRoom('c-dev', 'game:r', wsDev)
+
+    const stateAfterJoin = (mgr as any).rooms.get('game:r').state as GameState
+    expect(stateAfterJoin.humans['usr-1']).toEqual({ email: 'alice@example.com', plan: 'enterprise' })
+    expect(stateAfterJoin.bots['bot-42']).toEqual({ model: 'claude-opus-4-7' })
+    expect(stateAfterJoin.devices['dev-xyz']).toEqual({ location: 'sala-2' })
+
+    // Simulate abrupt disconnect of just the bot.
+    await mgr.cleanupComponent('c-bot')
+
+    const stateAfterLeave = (mgr as any).rooms.get('game:r').state as GameState
+    expect(stateAfterLeave.bots['bot-42']).toBeUndefined() // bot gone
+    expect(stateAfterLeave.humans['usr-1']).toBeDefined()  // user untouched
+    expect(stateAfterLeave.devices['dev-xyz']).toBeDefined() // device untouched
+  })
+
+  it('session is auto-derived from ws.data.authContext without explicit joinContext', async () => {
+    // Caller doesn't pass joinContext at all — the manager pulls session from
+    // the websocket's auth context. This is the path real transport adapters
+    // (Elysia/Express/Fastify) take.
+    const authMgr = new LiveAuthManager()
+    authMgr.register(new MyMixedProvider())
+    const { mgr, registry } = makeRoomManager()
+
+    let captured: any = null
+    class R extends LiveRoom<{ ok: boolean }> {
+      static roomName = 'auto-derive'
+      static defaultState = { ok: true }
+      onJoin(ctx: any) { captured = ctx.session }
+    }
+    registry.register(R as any)
+
+    const ctx = await authMgr.authenticate({ token: 'bot-token' })
+    const ws = createMockWS({ authContext: ctx, userId: ctx.session?.id })
+
+    await mgr.joinRoom('c-1', 'auto-derive:r', ws) // NO joinContext
+
+    expect(captured).toEqual({
+      id: 'bot-42',
+      kind: 'bot',
+      model: 'claude-opus-4-7',
+      ownerOrgId: 'org-7',
+      allowedActions: ['summarize', 'reply'],
+    })
+  })
+
+  it('anonymous user (no provider match) → session is undefined throughout', async () => {
+    const authMgr = new LiveAuthManager()
+    authMgr.register(new MyMixedProvider())
+    const { mgr, registry } = makeRoomManager()
+
+    const events: any[] = []
+    class R extends LiveRoom<{ x: number }> {
+      static roomName = 'anon-flow'
+      static defaultState = { x: 0 }
+      onJoin(ctx: any) { events.push({ phase: 'join', session: ctx.session, userId: ctx.userId }) }
+      onLeave(ctx: any) { events.push({ phase: 'leave', session: ctx.session, userId: ctx.userId }) }
+    }
+    registry.register(R as any)
+
+    // Wrong token → null → anonymous fallback in real flow
+    const ctx = await authMgr.authenticate({ token: 'unknown' })
+    expect(ctx.authenticated).toBe(false)
+
+    const ws = createMockWS({ authContext: ctx })
+    await mgr.joinRoom('c-1', 'anon-flow:r', ws)
+    await mgr.leaveRoom('c-1', 'anon-flow:r')
+
+    expect(events).toEqual([
+      { phase: 'join', session: undefined, userId: undefined },
+      { phase: 'leave', session: undefined, userId: undefined },
+    ])
+  })
+})

--- a/packages/core/src/__tests__/rooms/LiveRoomManager.membership-auth.test.ts
+++ b/packages/core/src/__tests__/rooms/LiveRoomManager.membership-auth.test.ts
@@ -1,0 +1,210 @@
+// Membership × auth interaction (#36). The membership bag must survive the
+// presence or absence of auth — and onJoin can stash auth-derived ids in it.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { LiveRoomManager } from '../../rooms/LiveRoomManager'
+import { LiveRoom } from '../../rooms/LiveRoom'
+import { RoomRegistry } from '../../rooms/RoomRegistry'
+import { RoomEventBus } from '../../rooms/RoomEventBus'
+import type { GenericWebSocket, LiveWSData } from '../../transport/types'
+import { ANONYMOUS_CONTEXT } from '../../auth/LiveAuthContext'
+import type { LiveAuthContext } from '../../auth/types'
+
+vi.mock('../../transport/WsSendBatcher', () => ({
+  queueWsMessage: vi.fn(),
+  queuePreSerialized: vi.fn(),
+  sendImmediate: vi.fn(),
+  sendBinaryImmediate: vi.fn(),
+}))
+vi.mock('../../debug/LiveLogger', () => ({
+  liveLog: vi.fn(),
+  liveWarn: vi.fn(),
+  registerComponentLogging: vi.fn(),
+  unregisterComponentLogging: vi.fn(),
+}))
+
+function fakeAuthContext(session: { id: string; roles?: string[] }): LiveAuthContext {
+  return {
+    authenticated: true,
+    session,
+    authenticatedAt: Date.now(),
+    hasRole: (r) => session.roles?.includes(r) ?? false,
+    hasAnyRole: (rs) => rs.some(r => session.roles?.includes(r)),
+    hasAllRoles: (rs) => rs.every(r => session.roles?.includes(r)),
+    hasPermission: () => false,
+    hasAllPermissions: () => false,
+    hasAnyPermission: () => false,
+  }
+}
+
+function makeWS(authContext: LiveAuthContext = ANONYMOUS_CONTEXT): GenericWebSocket {
+  const data: LiveWSData = {
+    connectionId: `ws-${Math.random().toString(36).slice(2, 10)}`,
+    components: new Map(),
+    subscriptions: new Set(),
+    connectedAt: new Date(),
+    userId: authContext.authenticated ? authContext.session?.id : undefined,
+    authContext,
+  }
+  return {
+    send: () => {},
+    close: () => {},
+    data,
+    remoteAddress: '127.0.0.1',
+    readyState: 1 as const,
+  } as any
+}
+
+function makeManager() {
+  const bus = new RoomEventBus()
+  const mgr = new LiveRoomManager(bus)
+  const registry = new RoomRegistry()
+  mgr.roomRegistry = registry
+  return { mgr, registry }
+}
+
+let errSpy: ReturnType<typeof vi.spyOn>
+beforeEach(() => { errSpy = vi.spyOn(console, 'error').mockImplementation(() => {}) })
+afterEach(() => { errSpy.mockRestore(); vi.clearAllMocks() })
+
+describe('membership × auth (#36)', () => {
+  it('joinContext.userId is forwarded to onJoin', async () => {
+    const { mgr, registry } = makeManager()
+    let seen: any = null
+
+    class R extends LiveRoom<{ ok: boolean }> {
+      static roomName = 'auth-r'
+      static defaultState = { ok: true }
+      onJoin(ctx: any) { seen = { userId: ctx.userId, payload: ctx.payload } }
+    }
+    registry.register(R as any)
+
+    const ws = makeWS(fakeAuthContext({ id: 'user-42', roles: ['user'] }))
+    await mgr.joinRoom('c-1', 'auth-r:room', ws, undefined, undefined, {
+      userId: 'user-42',
+      payload: { extra: 'data' },
+    })
+
+    expect(seen).toEqual({ userId: 'user-42', payload: { extra: 'data' } })
+  })
+
+  it('userId from auth is preserved in onLeave via membership', async () => {
+    const { mgr, registry } = makeManager()
+    let leftSeen: any = null
+
+    class TrophyRoom extends LiveRoom<{ players: Record<string, any> }> {
+      static roomName = 'trophy'
+      static defaultState = { players: {} }
+      onJoin(ctx: any) {
+        // Stash auth-derived id in membership for later cleanup.
+        ctx.membership.userId = ctx.userId
+        if (ctx.userId) this.state.players[ctx.userId] = { joinedAt: Date.now() }
+      }
+      onLeave(ctx: any) {
+        leftSeen = { userId: ctx.userId, membership: ctx.membership }
+        if (ctx.membership.userId) delete this.state.players[ctx.membership.userId]
+      }
+    }
+    registry.register(TrophyRoom as any)
+
+    await mgr.joinRoom('c-1', 'trophy:lobby', makeWS(), undefined, undefined, {
+      userId: 'alice',
+    })
+    expect((mgr as any).rooms.get('trophy:lobby').state.players.alice).toBeDefined()
+
+    await mgr.cleanupComponent('c-1')
+
+    expect(leftSeen.userId).toBe('alice')
+    expect(leftSeen.membership).toEqual({ userId: 'alice' })
+    expect((mgr as any).rooms.get('trophy:lobby').state.players.alice).toBeUndefined()
+  })
+
+  it('membership works for anonymous users (no userId)', async () => {
+    const { mgr, registry } = makeManager()
+    let leftSeen: any = null
+
+    class R extends LiveRoom<{ x: number }> {
+      static roomName = 'anon'
+      static defaultState = { x: 0 }
+      onJoin(ctx: any) {
+        // No userId — fall back to a guest token in membership.
+        ctx.membership.guestToken = `guest-${Math.random().toString(36).slice(2, 8)}`
+      }
+      onLeave(ctx: any) { leftSeen = ctx }
+    }
+    registry.register(R as any)
+
+    await mgr.joinRoom('c-1', 'anon:r', makeWS()) // no joinContext at all
+    await mgr.leaveRoom('c-1', 'anon:r')
+
+    expect(leftSeen.userId).toBeUndefined()
+    expect(leftSeen.membership.guestToken).toMatch(/^guest-/)
+  })
+
+  it('two authenticated users in the same room have independent membership', async () => {
+    const { mgr, registry } = makeManager()
+    const seen: any[] = []
+
+    class R extends LiveRoom<{ x: number }> {
+      static roomName = 'multi-auth'
+      static defaultState = { x: 0 }
+      onJoin(ctx: any) {
+        ctx.membership.userId = ctx.userId
+        ctx.membership.role = ctx.payload?.role
+      }
+      onLeave(ctx: any) { seen.push(ctx.membership) }
+    }
+    registry.register(R as any)
+
+    await mgr.joinRoom('a', 'multi-auth:r', makeWS(fakeAuthContext({ id: 'alice', roles: ['admin'] })), undefined, undefined, {
+      userId: 'alice',
+      payload: { role: 'admin' },
+    })
+    await mgr.joinRoom('b', 'multi-auth:r', makeWS(fakeAuthContext({ id: 'bob', roles: ['user'] })), undefined, undefined, {
+      userId: 'bob',
+      payload: { role: 'user' },
+    })
+
+    await mgr.cleanupComponent('a')
+    await mgr.cleanupComponent('b')
+
+    expect(seen).toEqual([
+      { userId: 'alice', role: 'admin' },
+      { userId: 'bob', role: 'user' },
+    ])
+  })
+
+  it('membership populated from auth roles is recoverable in onLeave', async () => {
+    const { mgr, registry } = makeManager()
+    const audits: any[] = []
+
+    class AdminRoom extends LiveRoom<{ active: string[] }> {
+      static roomName = 'admin'
+      static defaultState = { active: [] as string[] }
+      onJoin(ctx: any) {
+        // In real code this would come from ws.data.authContext.session.roles.
+        // We pass it through joinContext.payload to keep the test self-contained.
+        ctx.membership.roles = ctx.payload.roles
+        ctx.membership.userId = ctx.userId
+      }
+      onLeave(ctx: any) {
+        audits.push({
+          userId: ctx.membership.userId,
+          wasAdmin: ctx.membership.roles?.includes('admin'),
+          reason: ctx.reason,
+        })
+      }
+    }
+    registry.register(AdminRoom as any)
+
+    await mgr.joinRoom('c-1', 'admin:panel', makeWS(), undefined, undefined, {
+      userId: 'root',
+      payload: { roles: ['admin', 'user'] },
+    })
+    await mgr.cleanupComponent('c-1') // simulate tab close
+
+    expect(audits).toEqual([
+      { userId: 'root', wasAdmin: true, reason: 'disconnect' },
+    ])
+  })
+})

--- a/packages/core/src/__tests__/rooms/LiveRoomManager.membership-edge.test.ts
+++ b/packages/core/src/__tests__/rooms/LiveRoomManager.membership-edge.test.ts
@@ -1,0 +1,277 @@
+// Edge-case coverage for RoomLeaveContext.membership (#36).
+// Covers async hooks, multi-room scenarios, mutation patterns, throw-isolation,
+// and the interaction with onJoin rejection.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { LiveRoomManager } from '../../rooms/LiveRoomManager'
+import { LiveRoom } from '../../rooms/LiveRoom'
+import { RoomRegistry } from '../../rooms/RoomRegistry'
+import { RoomEventBus } from '../../rooms/RoomEventBus'
+import type { GenericWebSocket, LiveWSData } from '../../transport/types'
+import { ANONYMOUS_CONTEXT } from '../../auth/LiveAuthContext'
+
+vi.mock('../../transport/WsSendBatcher', () => ({
+  queueWsMessage: vi.fn(),
+  queuePreSerialized: vi.fn(),
+  sendImmediate: vi.fn(),
+  sendBinaryImmediate: vi.fn(),
+}))
+vi.mock('../../debug/LiveLogger', () => ({
+  liveLog: vi.fn(),
+  liveWarn: vi.fn(),
+  registerComponentLogging: vi.fn(),
+  unregisterComponentLogging: vi.fn(),
+}))
+
+function createMockWS(): GenericWebSocket {
+  const data: LiveWSData = {
+    connectionId: `ws-${Math.random().toString(36).slice(2, 10)}`,
+    components: new Map(),
+    subscriptions: new Set(),
+    connectedAt: new Date(),
+    userId: undefined,
+    authContext: ANONYMOUS_CONTEXT,
+  }
+  return {
+    send: () => {},
+    close: () => {},
+    data,
+    remoteAddress: '127.0.0.1',
+    readyState: 1 as const,
+  } as any
+}
+
+function makeManager() {
+  const bus = new RoomEventBus()
+  const mgr = new LiveRoomManager(bus)
+  const registry = new RoomRegistry()
+  mgr.roomRegistry = registry
+  return { mgr, registry }
+}
+
+let errSpy: ReturnType<typeof vi.spyOn>
+beforeEach(() => { errSpy = vi.spyOn(console, 'error').mockImplementation(() => {}) })
+afterEach(() => { errSpy.mockRestore(); vi.clearAllMocks() })
+
+describe('membership — async hooks (#36)', () => {
+  it('async onJoin mutations are visible in async onLeave', async () => {
+    const { mgr, registry } = makeManager()
+    let captured: any = null
+
+    class R extends LiveRoom<{ x: number }> {
+      static roomName = 'async-r'
+      static defaultState = { x: 0 }
+      async onJoin(ctx: any) {
+        await Promise.resolve()
+        ctx.membership.token = 'abc-' + ctx.payload.id
+      }
+      async onLeave(ctx: any) {
+        await Promise.resolve()
+        captured = ctx.membership
+      }
+    }
+    registry.register(R as any)
+
+    await mgr.joinRoom('c-1', 'async-r:room', createMockWS(), undefined, undefined, {
+      payload: { id: 42 },
+    })
+    await mgr.leaveRoom('c-1', 'async-r:room')
+
+    expect(captured).toEqual({ token: 'abc-42' })
+  })
+
+  it('membership is NOT persisted when onJoin rejects (false)', async () => {
+    const { mgr, registry } = makeManager()
+    const leaves: any[] = []
+
+    class R extends LiveRoom<{ x: number }> {
+      static roomName = 'reject-r'
+      static defaultState = { x: 0 }
+      onJoin(ctx: any): false {
+        ctx.membership.shouldNotPersist = true
+        return false // reject
+      }
+      onLeave(ctx: any) { leaves.push(ctx) }
+    }
+    registry.register(R as any)
+
+    const result = await mgr.joinRoom('c-1', 'reject-r:room', createMockWS())
+    expect((result as any).rejected).toBe(true)
+
+    // No member was actually added → leaveRoom for this comp is a no-op,
+    // onLeave must not fire.
+    await mgr.leaveRoom('c-1', 'reject-r:room')
+    expect(leaves).toHaveLength(0)
+  })
+
+  it('membership is NOT persisted when onJoin throws', async () => {
+    const { mgr, registry } = makeManager()
+    const leaves: any[] = []
+
+    class R extends LiveRoom<{ x: number }> {
+      static roomName = 'throw-r'
+      static defaultState = { x: 0 }
+      onJoin(ctx: any) {
+        ctx.membership.bad = true
+        throw new Error('boom')
+      }
+      onLeave(ctx: any) { leaves.push(ctx) }
+    }
+    registry.register(R as any)
+
+    const result = await mgr.joinRoom('c-1', 'throw-r:room', createMockWS())
+    expect((result as any).rejected).toBe(true)
+
+    await mgr.leaveRoom('c-1', 'throw-r:room')
+    expect(leaves).toHaveLength(0)
+  })
+})
+
+describe('membership — multi-room cleanup (#36)', () => {
+  it('cleanupComponent surfaces the correct membership per room', async () => {
+    const { mgr, registry } = makeManager()
+    const leaves: Array<{ roomId: string; membership: any }> = []
+
+    class Lobby extends LiveRoom<{ x: number }> {
+      static roomName = 'lobby'
+      static defaultState = { x: 0 }
+      onJoin(ctx: any) { ctx.membership.role = 'lobby-' + ctx.payload.name }
+      onLeave(ctx: any) { leaves.push({ roomId: this.id, membership: ctx.membership }) }
+    }
+    class Game extends LiveRoom<{ y: number }> {
+      static roomName = 'game'
+      static defaultState = { y: 0 }
+      onJoin(ctx: any) { ctx.membership.role = 'game-' + ctx.payload.name }
+      onLeave(ctx: any) { leaves.push({ roomId: this.id, membership: ctx.membership }) }
+    }
+    registry.register(Lobby as any)
+    registry.register(Game as any)
+
+    await mgr.joinRoom('c-1', 'lobby:main', createMockWS(), undefined, undefined, {
+      payload: { name: 'Alice' },
+    })
+    await mgr.joinRoom('c-1', 'game:arena', createMockWS(), undefined, undefined, {
+      payload: { name: 'Alice' },
+    })
+
+    await mgr.cleanupComponent('c-1')
+
+    expect(leaves).toHaveLength(2)
+    const byRoom = Object.fromEntries(leaves.map(l => [l.roomId, l.membership]))
+    expect(byRoom['lobby:main']).toEqual({ role: 'lobby-Alice' })
+    expect(byRoom['game:arena']).toEqual({ role: 'game-Alice' })
+  })
+
+  it('a throwing onLeave does not corrupt subsequent rooms membership', async () => {
+    const { mgr, registry } = makeManager()
+    const leaves: any[] = []
+
+    class A extends LiveRoom<{ x: number }> {
+      static roomName = 'a'
+      static defaultState = { x: 0 }
+      onJoin(ctx: any) { ctx.membership.tag = 'A' }
+      onLeave(_ctx: any) { throw new Error('A failed') }
+    }
+    class B extends LiveRoom<{ y: number }> {
+      static roomName = 'b'
+      static defaultState = { y: 0 }
+      onJoin(ctx: any) { ctx.membership.tag = 'B' }
+      onLeave(ctx: any) { leaves.push(ctx.membership) }
+    }
+    registry.register(A as any)
+    registry.register(B as any)
+
+    await mgr.joinRoom('c-1', 'a:r', createMockWS())
+    await mgr.joinRoom('c-1', 'b:r', createMockWS())
+
+    await mgr.cleanupComponent('c-1')
+
+    expect(leaves).toEqual([{ tag: 'B' }])
+  })
+})
+
+describe('membership — mutation patterns (#36)', () => {
+  it('supports replacing membership content during the membership lifetime', async () => {
+    const { mgr, registry } = makeManager()
+    let snapshot: any = null
+
+    class R extends LiveRoom<{ score: number }> {
+      static roomName = 'mut'
+      static defaultState = { score: 0 }
+      onJoin(ctx: any) { ctx.membership.score = 0; ctx.membership.id = 'p-1' }
+      onLeave(ctx: any) { snapshot = { ...ctx.membership } }
+    }
+    registry.register(R as any)
+
+    await mgr.joinRoom('c-1', 'mut:r', createMockWS())
+
+    // Domain code mutates membership outside the lifecycle hooks via the
+    // member entry — verify by mutating the underlying map (room-keyed by
+    // componentId) and confirming onLeave sees the mutation.
+    const room = (mgr as any).rooms.get('mut:r')
+    room.members.get('c-1').membership.score = 99
+
+    await mgr.leaveRoom('c-1', 'mut:r')
+    expect(snapshot).toEqual({ score: 99, id: 'p-1' })
+  })
+
+  it('membership for componentId B is independent of componentId A in the same room', async () => {
+    const { mgr, registry } = makeManager()
+    const seen: Record<string, any> = {}
+
+    class R extends LiveRoom<{ x: number }> {
+      static roomName = 'iso'
+      static defaultState = { x: 0 }
+      onJoin(ctx: any) { ctx.membership.who = ctx.payload.who }
+      onLeave(ctx: any) { seen[ctx.componentId] = ctx.membership }
+    }
+    registry.register(R as any)
+
+    await mgr.joinRoom('a', 'iso:r', createMockWS(), undefined, undefined, { payload: { who: 'A' } })
+    await mgr.joinRoom('b', 'iso:r', createMockWS(), undefined, undefined, { payload: { who: 'B' } })
+
+    // Mutate A's membership; B should not see the mutation.
+    const room = (mgr as any).rooms.get('iso:r')
+    room.members.get('a').membership.who = 'A-MUTATED'
+
+    await mgr.leaveRoom('a', 'iso:r')
+    await mgr.leaveRoom('b', 'iso:r')
+
+    expect(seen['a']).toEqual({ who: 'A-MUTATED' })
+    expect(seen['b']).toEqual({ who: 'B' })
+  })
+})
+
+describe('membership — leave reason variants (#36)', () => {
+  it('preserves membership on explicit leave', async () => {
+    const { mgr, registry } = makeManager()
+    let r: any = null
+    class R extends LiveRoom<{ x: number }> {
+      static roomName = 'lr'
+      static defaultState = { x: 0 }
+      onJoin(ctx: any) { ctx.membership.id = 'leave' }
+      onLeave(ctx: any) { r = ctx }
+    }
+    registry.register(R as any)
+    await mgr.joinRoom('c', 'lr:r', createMockWS())
+    await mgr.leaveRoom('c', 'lr:r', 'leave')
+    expect(r.reason).toBe('leave')
+    expect(r.membership).toEqual({ id: 'leave' })
+  })
+
+  it('preserves membership on cleanup reason', async () => {
+    const { mgr, registry } = makeManager()
+    let r: any = null
+    class R extends LiveRoom<{ x: number }> {
+      static roomName = 'cr'
+      static defaultState = { x: 0 }
+      onJoin(ctx: any) { ctx.membership.id = 'cleanup' }
+      onLeave(ctx: any) { r = ctx }
+    }
+    registry.register(R as any)
+    await mgr.joinRoom('c', 'cr:r', createMockWS())
+    await mgr.leaveRoom('c', 'cr:r', 'cleanup')
+    expect(r.reason).toBe('cleanup')
+    expect(r.membership).toEqual({ id: 'cleanup' })
+  })
+})

--- a/packages/core/src/__tests__/rooms/LiveRoomManager.membership.test.ts
+++ b/packages/core/src/__tests__/rooms/LiveRoomManager.membership.test.ts
@@ -1,0 +1,164 @@
+// Regression tests for issue #36: RoomLeaveContext.membership.
+//
+// Before the fix, onLeave only received { componentId, userId?, reason }. Rooms
+// keying their state by an app id (e.g. `state.players[playerId]`) had no way
+// to find the entry to remove on abrupt disconnect, because `destroy()` on
+// the component doesn't always run.
+//
+// The fix threads a per-member metadata bag through the lifecycle: onJoin can
+// stash domain ids into ctx.membership, and the same object is handed back
+// to onLeave for cleanup.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { LiveRoomManager } from '../../rooms/LiveRoomManager'
+import { LiveRoom } from '../../rooms/LiveRoom'
+import { RoomRegistry } from '../../rooms/RoomRegistry'
+import { RoomEventBus } from '../../rooms/RoomEventBus'
+import type { GenericWebSocket, LiveWSData } from '../../transport/types'
+import { ANONYMOUS_CONTEXT } from '../../auth/LiveAuthContext'
+
+vi.mock('../../transport/WsSendBatcher', () => ({
+  queueWsMessage: vi.fn(),
+  queuePreSerialized: vi.fn(),
+  sendImmediate: vi.fn(),
+  sendBinaryImmediate: vi.fn(),
+}))
+vi.mock('../../debug/LiveLogger', () => ({
+  liveLog: vi.fn(),
+  liveWarn: vi.fn(),
+  registerComponentLogging: vi.fn(),
+  unregisterComponentLogging: vi.fn(),
+}))
+
+function createMockWS(): GenericWebSocket {
+  const data: LiveWSData = {
+    connectionId: `ws-${Math.random().toString(36).slice(2, 10)}`,
+    components: new Map(),
+    subscriptions: new Set(),
+    connectedAt: new Date(),
+    userId: undefined,
+    authContext: ANONYMOUS_CONTEXT,
+  }
+  return {
+    send: () => {},
+    close: () => {},
+    data,
+    remoteAddress: '127.0.0.1',
+    readyState: 1 as const,
+  } as any
+}
+
+function makeManager() {
+  const bus = new RoomEventBus()
+  const mgr = new LiveRoomManager(bus)
+  const registry = new RoomRegistry()
+  mgr.roomRegistry = registry
+  return { mgr, registry }
+}
+
+let errSpy: ReturnType<typeof vi.spyOn>
+beforeEach(() => { errSpy = vi.spyOn(console, 'error').mockImplementation(() => {}) })
+afterEach(() => { errSpy.mockRestore(); vi.clearAllMocks() })
+
+interface PlayerState { players: Record<string, { id: string; name: string }> }
+
+describe('RoomLeaveContext.membership (#36)', () => {
+  it('onLeave receives the membership bag populated by onJoin (explicit leave)', async () => {
+    const { mgr, registry } = makeManager()
+    const leaveCalls: any[] = []
+
+    class TrophyRoom extends LiveRoom<PlayerState> {
+      static roomName = 'trophy'
+      static defaultState = { players: {} }
+      onJoin(ctx: any) {
+        const playerId = ctx.payload?.playerId
+        ctx.membership.playerId = playerId
+        this.state.players[playerId] = { id: playerId, name: ctx.payload.name }
+      }
+      onLeave(ctx: any) {
+        leaveCalls.push({ componentId: ctx.componentId, membership: ctx.membership })
+        delete this.state.players[ctx.membership.playerId]
+      }
+    }
+    registry.register(TrophyRoom as any)
+
+    await mgr.joinRoom('comp-1', 'trophy:lobby', createMockWS(), undefined, undefined, {
+      payload: { playerId: 'p-42', name: 'Alice' },
+    })
+
+    const before = (mgr as any).rooms.get('trophy:lobby')!.state.players
+    expect(before['p-42']).toEqual({ id: 'p-42', name: 'Alice' })
+
+    await mgr.leaveRoom('comp-1', 'trophy:lobby', 'leave')
+
+    expect(leaveCalls).toEqual([
+      { componentId: 'comp-1', membership: { playerId: 'p-42' } },
+    ])
+    const after = (mgr as any).rooms.get('trophy:lobby')!.state.players
+    expect(after['p-42']).toBeUndefined()
+  })
+
+  it('membership is preserved on abrupt disconnect (cleanupComponent path)', async () => {
+    const { mgr, registry } = makeManager()
+    const leaveCalls: any[] = []
+
+    class TrophyRoom extends LiveRoom<PlayerState> {
+      static roomName = 'trophy'
+      static defaultState = { players: {} }
+      onJoin(ctx: any) {
+        ctx.membership.playerId = ctx.payload.playerId
+        this.state.players[ctx.payload.playerId] = { id: ctx.payload.playerId, name: 'x' }
+      }
+      onLeave(ctx: any) { leaveCalls.push(ctx) }
+    }
+    registry.register(TrophyRoom as any)
+
+    await mgr.joinRoom('comp-1', 'trophy:lobby', createMockWS(), undefined, undefined, {
+      payload: { playerId: 'p-99' },
+    })
+
+    await mgr.cleanupComponent('comp-1')
+
+    expect(leaveCalls).toHaveLength(1)
+    expect(leaveCalls[0].reason).toBe('disconnect')
+    expect(leaveCalls[0].membership).toEqual({ playerId: 'p-99' })
+  })
+
+  it('membership defaults to {} when onJoin does not populate it', async () => {
+    const { mgr, registry } = makeManager()
+    let captured: any = null
+
+    class SimpleRoom extends LiveRoom<{ ok: boolean }> {
+      static roomName = 'simple'
+      static defaultState = { ok: true }
+      onLeave(ctx: any) { captured = ctx.membership }
+    }
+    registry.register(SimpleRoom as any)
+
+    await mgr.joinRoom('c-1', 'simple:room', createMockWS())
+    await mgr.leaveRoom('c-1', 'simple:room')
+
+    expect(captured).toEqual({})
+  })
+
+  it('different members have independent membership bags', async () => {
+    const { mgr, registry } = makeManager()
+    const seen: any[] = []
+
+    class R extends LiveRoom<{ x: number }> {
+      static roomName = 'multi'
+      static defaultState = { x: 0 }
+      onJoin(ctx: any) { ctx.membership.tag = ctx.payload.tag }
+      onLeave(ctx: any) { seen.push(ctx.membership.tag) }
+    }
+    registry.register(R as any)
+
+    await mgr.joinRoom('a', 'multi:r', createMockWS(), undefined, undefined, { payload: { tag: 'A' } })
+    await mgr.joinRoom('b', 'multi:r', createMockWS(), undefined, undefined, { payload: { tag: 'B' } })
+
+    await mgr.leaveRoom('a', 'multi:r')
+    await mgr.leaveRoom('b', 'multi:r')
+
+    expect(seen).toEqual(['A', 'B'])
+  })
+})

--- a/packages/core/src/__tests__/rooms/LiveRoomManager.session-context.test.ts
+++ b/packages/core/src/__tests__/rooms/LiveRoomManager.session-context.test.ts
@@ -1,0 +1,265 @@
+// RoomJoinContext.session / RoomLeaveContext.session — full auth session
+// reaches the lifecycle hooks, not just the id. Confirms the API is generic
+// (works for user/bot/device sessions defined by the provider).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { LiveRoomManager } from '../../rooms/LiveRoomManager'
+import { LiveRoom } from '../../rooms/LiveRoom'
+import { RoomRegistry } from '../../rooms/RoomRegistry'
+import { RoomEventBus } from '../../rooms/RoomEventBus'
+import type { GenericWebSocket, LiveWSData } from '../../transport/types'
+import { ANONYMOUS_CONTEXT } from '../../auth/LiveAuthContext'
+import type { LiveAuthContext, LiveAuthSession } from '../../auth/types'
+
+vi.mock('../../transport/WsSendBatcher', () => ({
+  queueWsMessage: vi.fn(),
+  queuePreSerialized: vi.fn(),
+  sendImmediate: vi.fn(),
+  sendBinaryImmediate: vi.fn(),
+}))
+vi.mock('../../debug/LiveLogger', () => ({
+  liveLog: vi.fn(),
+  liveWarn: vi.fn(),
+  registerComponentLogging: vi.fn(),
+  unregisterComponentLogging: vi.fn(),
+}))
+
+function authCtxFor(session: LiveAuthSession): LiveAuthContext {
+  return {
+    authenticated: true,
+    session,
+    authenticatedAt: Date.now(),
+    hasRole: (r) => session.roles?.includes(r) ?? false,
+    hasAnyRole: (rs) => rs.some(r => session.roles?.includes(r) ?? false),
+    hasAllRoles: (rs) => rs.every(r => session.roles?.includes(r) ?? false),
+    hasPermission: (p) => session.permissions?.includes(p) ?? false,
+    hasAllPermissions: (ps) => ps.every(p => session.permissions?.includes(p) ?? false),
+    hasAnyPermission: (ps) => ps.some(p => session.permissions?.includes(p) ?? false),
+  }
+}
+
+function wsWithAuth(authContext: LiveAuthContext): GenericWebSocket {
+  const data: LiveWSData = {
+    connectionId: `ws-${Math.random().toString(36).slice(2, 10)}`,
+    components: new Map(),
+    subscriptions: new Set(),
+    connectedAt: new Date(),
+    userId: authContext.authenticated ? authContext.session?.id : undefined,
+    authContext,
+  }
+  return {
+    send: () => {},
+    close: () => {},
+    data,
+    remoteAddress: '127.0.0.1',
+    readyState: 1 as const,
+  } as any
+}
+
+function makeManager() {
+  const bus = new RoomEventBus()
+  const mgr = new LiveRoomManager(bus)
+  const registry = new RoomRegistry()
+  mgr.roomRegistry = registry
+  return { mgr, registry }
+}
+
+let errSpy: ReturnType<typeof vi.spyOn>
+beforeEach(() => { errSpy = vi.spyOn(console, 'error').mockImplementation(() => {}) })
+afterEach(() => { errSpy.mockRestore(); vi.clearAllMocks() })
+
+describe('RoomJoinContext.session — generic auth payload', () => {
+  it('auto-derives session from ws.data.authContext when joinContext omits it', async () => {
+    const { mgr, registry } = makeManager()
+    let captured: any = null
+
+    class R extends LiveRoom<{ ok: boolean }> {
+      static roomName = 'auto'
+      static defaultState = { ok: true }
+      onJoin(ctx: any) { captured = ctx.session }
+    }
+    registry.register(R as any)
+
+    const ws = wsWithAuth(authCtxFor({ id: 'usr-1', email: 'a@b.com', plan: 'pro' }))
+    await mgr.joinRoom('c-1', 'auto:r', ws) // no joinContext at all
+
+    expect(captured).toMatchObject({ id: 'usr-1', email: 'a@b.com', plan: 'pro' })
+  })
+
+  it('exposes the full session shape — not just the id — for bot providers', async () => {
+    const { mgr, registry } = makeManager()
+    let captured: any = null
+
+    class BotRoom extends LiveRoom<{ active: string[] }> {
+      static roomName = 'bot'
+      static defaultState = { active: [] as string[] }
+      onJoin(ctx: any) { captured = ctx.session }
+    }
+    registry.register(BotRoom as any)
+
+    const ws = wsWithAuth(authCtxFor({
+      id: 'bot-42',
+      kind: 'bot',
+      model: 'gpt-4',
+      allowedActions: ['summarize', 'reply'],
+    }))
+    await mgr.joinRoom('c-1', 'bot:room', ws)
+
+    expect(captured).toEqual({
+      id: 'bot-42',
+      kind: 'bot',
+      model: 'gpt-4',
+      allowedActions: ['summarize', 'reply'],
+    })
+  })
+
+  it('exposes the full session shape for IoT device providers', async () => {
+    const { mgr, registry } = makeManager()
+    let captured: any = null
+
+    class DeviceRoom extends LiveRoom<{ devices: any[] }> {
+      static roomName = 'iot'
+      static defaultState = { devices: [] as any[] }
+      onJoin(ctx: any) { captured = ctx.session }
+    }
+    registry.register(DeviceRoom as any)
+
+    const ws = wsWithAuth(authCtxFor({
+      id: 'dev-xyz',
+      deviceType: 'sensor',
+      location: 'sala-2',
+      firmware: '1.4.0',
+    }))
+    await mgr.joinRoom('c-1', 'iot:room', ws)
+
+    expect(captured.deviceType).toBe('sensor')
+    expect(captured.location).toBe('sala-2')
+    expect(captured.firmware).toBe('1.4.0')
+  })
+
+  it('joinContext.session takes precedence over ws.data.authContext.session', async () => {
+    const { mgr, registry } = makeManager()
+    let captured: any = null
+
+    class R extends LiveRoom<{ x: number }> {
+      static roomName = 'override'
+      static defaultState = { x: 0 }
+      onJoin(ctx: any) { captured = ctx.session }
+    }
+    registry.register(R as any)
+
+    const ws = wsWithAuth(authCtxFor({ id: 'from-ws', kind: 'auto' }))
+    await mgr.joinRoom('c-1', 'override:r', ws, undefined, undefined, {
+      session: { id: 'from-caller', kind: 'manual' } as LiveAuthSession,
+    })
+
+    expect(captured).toEqual({ id: 'from-caller', kind: 'manual' })
+  })
+
+  it('session is undefined for anonymous ws (no auth context)', async () => {
+    const { mgr, registry } = makeManager()
+    let captured: any = '__SENTINEL__'
+
+    class R extends LiveRoom<{ x: number }> {
+      static roomName = 'anon-r'
+      static defaultState = { x: 0 }
+      onJoin(ctx: any) { captured = ctx.session }
+    }
+    registry.register(R as any)
+
+    const ws = wsWithAuth(ANONYMOUS_CONTEXT)
+    await mgr.joinRoom('c-1', 'anon-r:room', ws)
+
+    expect(captured).toBeUndefined()
+  })
+
+  it('deprecated userId is still populated from session.id', async () => {
+    const { mgr, registry } = makeManager()
+    let captured: any = null
+
+    class R extends LiveRoom<{ x: number }> {
+      static roomName = 'dep'
+      static defaultState = { x: 0 }
+      onJoin(ctx: any) { captured = { userId: ctx.userId, sessionId: ctx.session?.id } }
+    }
+    registry.register(R as any)
+
+    const ws = wsWithAuth(authCtxFor({ id: 'usr-99', kind: 'user' }))
+    await mgr.joinRoom('c-1', 'dep:r', ws)
+
+    expect(captured.userId).toBe('usr-99')
+    expect(captured.sessionId).toBe('usr-99')
+  })
+})
+
+describe('RoomLeaveContext.session — survives to onLeave', () => {
+  it('session captured at onJoin is delivered intact to onLeave on explicit leave', async () => {
+    const { mgr, registry } = makeManager()
+    let leaveCtx: any = null
+
+    class R extends LiveRoom<{ x: number }> {
+      static roomName = 'sl'
+      static defaultState = { x: 0 }
+      onLeave(ctx: any) { leaveCtx = ctx }
+    }
+    registry.register(R as any)
+
+    const ws = wsWithAuth(authCtxFor({
+      id: 'bot-1',
+      kind: 'bot',
+      model: 'claude-3',
+    }))
+    await mgr.joinRoom('c-1', 'sl:r', ws)
+    await mgr.leaveRoom('c-1', 'sl:r', 'leave')
+
+    expect(leaveCtx.session).toEqual({ id: 'bot-1', kind: 'bot', model: 'claude-3' })
+    expect(leaveCtx.userId).toBe('bot-1') // deprecated alias still works
+  })
+
+  it('session survives abrupt disconnect (cleanupComponent path)', async () => {
+    const { mgr, registry } = makeManager()
+    let leaveCtx: any = null
+
+    class R extends LiveRoom<{ x: number }> {
+      static roomName = 'sl2'
+      static defaultState = { x: 0 }
+      onLeave(ctx: any) { leaveCtx = ctx }
+    }
+    registry.register(R as any)
+
+    const ws = wsWithAuth(authCtxFor({ id: 'dev-1', deviceType: 'sensor' }))
+    await mgr.joinRoom('c-1', 'sl2:r', ws)
+    await mgr.cleanupComponent('c-1')
+
+    expect(leaveCtx.session).toEqual({ id: 'dev-1', deviceType: 'sensor' })
+    expect(leaveCtx.reason).toBe('disconnect')
+  })
+
+  it('onLeave can read arbitrary session fields without consulting membership', async () => {
+    // The whole point: dev no longer needs to copy session fields into
+    // ctx.membership at onJoin just to get them back at onLeave.
+    const { mgr, registry } = makeManager()
+    const cleanupLog: any[] = []
+
+    class R extends LiveRoom<{ x: number }> {
+      static roomName = 'direct'
+      static defaultState = { x: 0 }
+      onLeave(ctx: any) {
+        if (ctx.session?.kind === 'bot') {
+          cleanupLog.push({ id: ctx.session.id, model: ctx.session.model })
+        }
+      }
+    }
+    registry.register(R as any)
+
+    await mgr.joinRoom('c-a', 'direct:r',
+      wsWithAuth(authCtxFor({ id: 'b-1', kind: 'bot', model: 'gpt-4' })))
+    await mgr.joinRoom('c-b', 'direct:r',
+      wsWithAuth(authCtxFor({ id: 'u-1', kind: 'user' }))) // not a bot
+
+    await mgr.cleanupComponent('c-a')
+    await mgr.cleanupComponent('c-b')
+
+    expect(cleanupLog).toEqual([{ id: 'b-1', model: 'gpt-4' }])
+  })
+})

--- a/packages/core/src/__tests__/security/property-update-injection.test.ts
+++ b/packages/core/src/__tests__/security/property-update-injection.test.ts
@@ -1,0 +1,178 @@
+// CVE-class regression: PROPERTY_UPDATE used to accept ANY property name
+// from the client, allowing a malicious frame to inject arbitrary fields
+// into a component's state (e.g. inject `session` so that subsequent
+// `this.state.session.id` reads in action handlers pick up an attacker-
+// controlled value).
+//
+// Fix in ComponentRegistry.updateProperty:
+//   1. Whitelist keys via `static defaultState` OR `static updatableFields`.
+//   2. Always reject prototype-pollution keys.
+//   3. Always reject `$`-prefixed keys (server-only convention).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { ComponentRegistry } from '../../component/ComponentRegistry'
+import { LiveComponent } from '../../component/LiveComponent'
+import { setLiveComponentContext } from '../../component/context'
+import { StateSignatureManager } from '../../security/StateSignature'
+import { LiveAuthManager } from '../../auth/LiveAuthManager'
+import { RoomEventBus } from '../../rooms/RoomEventBus'
+import { LiveRoomManager } from '../../rooms/LiveRoomManager'
+import { createMockWS } from '../helpers'
+
+vi.mock('../../transport/WsSendBatcher', () => ({
+  queueWsMessage: vi.fn(),
+  queuePreSerialized: vi.fn(),
+  sendImmediate: vi.fn(),
+  sendBinaryImmediate: vi.fn(),
+}))
+vi.mock('../../debug/LiveLogger', () => ({
+  liveLog: vi.fn(),
+  liveWarn: vi.fn(),
+  registerComponentLogging: vi.fn(),
+  unregisterComponentLogging: vi.fn(),
+}))
+
+class Counter extends LiveComponent<{ count: number; label: string }> {
+  static componentName = 'Counter'
+  static defaultState = { count: 0, label: 'hits' }
+  static publicActions = ['bump'] as const
+  bump() { this.setState({ count: (this.state as any).count + 1 }) }
+}
+
+class CounterWithAllowlist extends LiveComponent<{ count: number; label: string; secret: string }> {
+  static componentName = 'CounterWithAllowlist'
+  static defaultState = { count: 0, label: 'hits', secret: 'safe' }
+  // Only `count` is writable by the client — `secret` and `label` are not.
+  static updatableFields = ['count'] as const
+  static publicActions = [] as const
+}
+
+function createTestRegistry() {
+  const roomEvents = new RoomEventBus()
+  const roomManager = new LiveRoomManager(roomEvents)
+  const authManager = new LiveAuthManager()
+  const stateSignature = new StateSignatureManager({ secret: 'test-secret-32chars-minimum-ok!' })
+  setLiveComponentContext({ roomEvents, roomManager })
+
+  const performanceMonitor = {
+    initializeComponent: () => {},
+    recordRenderTime: () => {},
+    recordActionTime: () => {},
+    removeComponent: () => {},
+  }
+
+  return new ComponentRegistry({
+    authManager,
+    stateSignature,
+    performanceMonitor: performanceMonitor as any,
+  } as any)
+}
+
+let errSpy: ReturnType<typeof vi.spyOn>
+beforeEach(() => { errSpy = vi.spyOn(console, 'error').mockImplementation(() => {}) })
+afterEach(() => { errSpy.mockRestore(); vi.clearAllMocks() })
+
+describe('PROPERTY_UPDATE — injection defense', () => {
+  it('allows updating a key declared in defaultState', async () => {
+    const registry = createTestRegistry()
+    registry.registerComponentClass('Counter', Counter as any)
+    const ws = createMockWS()
+    const { componentId } = await registry.mountComponent(ws, 'Counter')
+
+    expect(() => registry.updateProperty(componentId, 'count', 99)).not.toThrow()
+    const comp = (registry as any).components.get(componentId)
+    expect((comp.state as any).count).toBe(99)
+  })
+
+  it('REJECTS injection of an unknown field (the issue)', async () => {
+    const registry = createTestRegistry()
+    registry.registerComponentClass('Counter', Counter as any)
+    const ws = createMockWS()
+    const { componentId } = await registry.mountComponent(ws, 'Counter')
+
+    // 🎯 Attack: try to inject `session` (would otherwise pollute state.session.id).
+    expect(() =>
+      registry.updateProperty(componentId, 'session', { id: 'admin-1', roles: ['admin'] }),
+    ).toThrow(/not an updatable field/)
+    const comp = (registry as any).components.get(componentId)
+    expect((comp.state as any).session).toBeUndefined()
+  })
+
+  it('REJECTS prototype-pollution keys (__proto__, constructor, prototype)', async () => {
+    const registry = createTestRegistry()
+    registry.registerComponentClass('Counter', Counter as any)
+    const ws = createMockWS()
+    const { componentId } = await registry.mountComponent(ws, 'Counter')
+
+    expect(() => registry.updateProperty(componentId, '__proto__', { polluted: true })).toThrow(/reserved key/)
+    expect(() => registry.updateProperty(componentId, 'constructor', {} as any)).toThrow(/reserved key/)
+    expect(() => registry.updateProperty(componentId, 'prototype', {} as any)).toThrow(/reserved key/)
+
+    expect((({} as any).polluted)).toBeUndefined()
+  })
+
+  it('REJECTS $-prefixed keys (server-only convention)', async () => {
+    const registry = createTestRegistry()
+    registry.registerComponentClass('Counter', Counter as any)
+    const ws = createMockWS()
+    const { componentId } = await registry.mountComponent(ws, 'Counter')
+
+    expect(() => registry.updateProperty(componentId, '$auth', { roles: ['admin'] })).toThrow(/server-only/)
+    expect(() => registry.updateProperty(componentId, '$private', { secret: 'x' })).toThrow(/server-only/)
+    expect(() => registry.updateProperty(componentId, '$anyCustom', 'x')).toThrow(/server-only/)
+  })
+
+  it('updatableFields allowlist OVERRIDES defaultState (stricter)', async () => {
+    const registry = createTestRegistry()
+    registry.registerComponentClass('CounterWithAllowlist', CounterWithAllowlist as any)
+    const ws = createMockWS()
+    const { componentId } = await registry.mountComponent(ws, 'CounterWithAllowlist')
+
+    expect(() => registry.updateProperty(componentId, 'count', 5)).not.toThrow()
+    expect(() => registry.updateProperty(componentId, 'secret', 'leaked')).toThrow(/not an updatable field/)
+    expect(() => registry.updateProperty(componentId, 'label', 'changed')).toThrow(/not an updatable field/)
+
+    const comp = (registry as any).components.get(componentId)
+    expect((comp.state as any).secret).toBe('safe')
+    expect((comp.state as any).label).toBe('hits')
+  })
+
+  it('rejection error message lists the allowed fields (helpful for devs)', async () => {
+    const registry = createTestRegistry()
+    registry.registerComponentClass('Counter', Counter as any)
+    const ws = createMockWS()
+    const { componentId } = await registry.mountComponent(ws, 'Counter')
+
+    try {
+      registry.updateProperty(componentId, 'nope', 1)
+      throw new Error('should have thrown')
+    } catch (err: any) {
+      expect(err.message).toContain('count')
+      expect(err.message).toContain('label')
+      expect(err.message).toContain('updatableFields')
+    }
+  })
+
+  it('server-side this.setState({$x: ...}) is unaffected — bypasses updateProperty', async () => {
+    // The $-prefix rule applies ONLY to the client-driven PROPERTY_UPDATE
+    // path. The server has full authority to mutate any field via setState.
+    const registry = createTestRegistry()
+    class WithDollar extends LiveComponent<{ count: number; $serverOnly: string }> {
+      static componentName = 'WithDollar'
+      static defaultState = { count: 0, $serverOnly: 'init' }
+      static publicActions = ['serverWrite'] as const
+      serverWrite() { this.setState({ $serverOnly: 'updated-by-server' } as any) }
+    }
+    registry.registerComponentClass('WithDollar', WithDollar as any)
+    const ws = createMockWS()
+    const { componentId } = await registry.mountComponent(ws, 'WithDollar')
+
+    // Client cannot write $serverOnly:
+    expect(() => registry.updateProperty(componentId, '$serverOnly', 'hacked')).toThrow(/server-only/)
+
+    // But the server-side action freely updates it via this.setState:
+    const comp = (registry as any).components.get(componentId)
+    comp.serverWrite()
+    expect((comp.state as any).$serverOnly).toBe('updated-by-server')
+  })
+})

--- a/packages/core/src/__tests__/security/room-state-injection.test.ts
+++ b/packages/core/src/__tests__/security/room-state-injection.test.ts
@@ -1,0 +1,132 @@
+// Defense against the same injection vector as PROPERTY_UPDATE, but on
+// the room-state path: ROOM_STATE_SET → setRoomState used to accept any
+// keys from the client, including `$`-prefixed (server-only convention)
+// and prototype-pollution keys.
+//
+// Fix: ROOM_STATE_SET now goes through setRoomStateFromClient which
+// strips `__proto__`, `constructor`, `prototype`, and `$`-prefixed keys.
+// The plain setRoomState path is preserved for server-internal callers
+// (they keep full authority over the state shape).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { LiveRoomManager } from '../../rooms/LiveRoomManager'
+import { RoomEventBus } from '../../rooms/RoomEventBus'
+import { createMockWS } from '../helpers'
+
+vi.mock('../../transport/WsSendBatcher', () => ({
+  queueWsMessage: vi.fn(),
+  queuePreSerialized: vi.fn(),
+  sendImmediate: vi.fn(),
+  sendBinaryImmediate: vi.fn(),
+}))
+vi.mock('../../debug/LiveLogger', () => ({
+  liveLog: vi.fn(),
+  liveWarn: vi.fn(),
+  registerComponentLogging: vi.fn(),
+  unregisterComponentLogging: vi.fn(),
+}))
+
+function makeMgr() {
+  return new LiveRoomManager(new RoomEventBus())
+}
+
+let errSpy: ReturnType<typeof vi.spyOn>
+beforeEach(() => { errSpy = vi.spyOn(console, 'error').mockImplementation(() => {}) })
+afterEach(() => { errSpy.mockRestore(); vi.clearAllMocks() })
+
+describe('setRoomStateFromClient — room-state injection defense', () => {
+  it('allows normal keys through unchanged', async () => {
+    const mgr = makeMgr()
+    const ws = createMockWS()
+    await mgr.joinRoom('c-1', 'lobby:r', ws, { count: 0, label: 'init' } as any)
+
+    mgr.setRoomStateFromClient('lobby:r', { count: 5, label: 'updated' }, 'c-1')
+
+    const state = (mgr as any).rooms.get('lobby:r').state
+    expect(state.count).toBe(5)
+    expect(state.label).toBe('updated')
+  })
+
+  it('STRIPS $-prefixed keys from client payload', async () => {
+    const mgr = makeMgr()
+    const ws = createMockWS()
+    await mgr.joinRoom('c-1', 'lobby:r', ws, { count: 0 } as any)
+
+    // 🎯 Attack: try to inject `$serverSecret` and `$auth`.
+    mgr.setRoomStateFromClient(
+      'lobby:r',
+      { count: 1, $serverSecret: 'leak', $auth: { roles: ['admin'] } },
+      'c-1',
+    )
+
+    const state = (mgr as any).rooms.get('lobby:r').state
+    expect(state.count).toBe(1)
+    expect(state.$serverSecret).toBeUndefined()
+    expect(state.$auth).toBeUndefined()
+  })
+
+  it('STRIPS prototype-pollution keys from client payload', async () => {
+    const mgr = makeMgr()
+    const ws = createMockWS()
+    await mgr.joinRoom('c-1', 'lobby:r', ws, { count: 0 } as any)
+
+    mgr.setRoomStateFromClient(
+      'lobby:r',
+      { count: 1, __proto__: { polluted: true }, constructor: 'evil', prototype: 'evil' } as any,
+      'c-1',
+    )
+
+    const state = (mgr as any).rooms.get('lobby:r').state
+    expect(state.count).toBe(1)
+    expect((state as any).__proto__).toEqual(Object.prototype) // still default proto
+    expect(state.constructor).toBe(Object) // unchanged
+    expect((state as any).prototype).toBeUndefined()
+    expect(({} as any).polluted).toBeUndefined() // Object.prototype intact
+  })
+
+  it('mixes safe and unsafe keys — safe survive, unsafe are dropped', async () => {
+    const mgr = makeMgr()
+    const ws = createMockWS()
+    await mgr.joinRoom('c-1', 'lobby:r', ws, { } as any)
+
+    mgr.setRoomStateFromClient('lobby:r', {
+      players: { p1: 'Alice' },
+      score: 100,
+      $internal: 'hidden',
+      __proto__: { x: 1 } as any,
+    }, 'c-1')
+
+    const state = (mgr as any).rooms.get('lobby:r').state
+    expect(state.players).toEqual({ p1: 'Alice' })
+    expect(state.score).toBe(100)
+    expect(state.$internal).toBeUndefined()
+  })
+
+  it('original setRoomState (server-side path) is NOT filtered', async () => {
+    // Server-side code (e.g. LiveRoom subclass setting state via this.state)
+    // must keep full authority — the filter is client-only.
+    const mgr = makeMgr()
+    const ws = createMockWS()
+    await mgr.joinRoom('c-1', 'lobby:r', ws, { count: 0 } as any)
+
+    mgr.setRoomState('lobby:r', { count: 1, $serverField: 'allowed' })
+
+    const state = (mgr as any).rooms.get('lobby:r').state
+    expect(state.count).toBe(1)
+    expect(state.$serverField).toBe('allowed') // server may use $-keys freely
+  })
+
+  it('null / non-object payload from client is treated as empty', async () => {
+    const mgr = makeMgr()
+    const ws = createMockWS()
+    await mgr.joinRoom('c-1', 'lobby:r', ws, { count: 0 } as any)
+
+    // Should not throw; state untouched.
+    expect(() => mgr.setRoomStateFromClient('lobby:r', null, 'c-1')).not.toThrow()
+    expect(() => mgr.setRoomStateFromClient('lobby:r', undefined as any, 'c-1')).not.toThrow()
+    expect(() => mgr.setRoomStateFromClient('lobby:r', 'string-payload' as any, 'c-1')).not.toThrow()
+
+    const state = (mgr as any).rooms.get('lobby:r').state
+    expect(state.count).toBe(0)
+  })
+})

--- a/packages/core/src/build/index.ts
+++ b/packages/core/src/build/index.ts
@@ -86,29 +86,97 @@ function extractDefaultState(classBody: string): string {
 
 /**
  * Remove `as <Type>` casts, handling nested generics/brackets.
+ *
+ * Critical: the scan must skip over string literals, template literals, and
+ * comments so that user data like `'Use as dicas!'` is never treated as a
+ * cast site (issue #33).
  */
 function stripAsCasts(s: string): string {
-  const RE = /\s+as\s+/g
-  let out = '', last = 0, m: RegExpExecArray | null
+  let out = ''
+  let i = 0
 
-  while ((m = RE.exec(s)) !== null) {
-    out += s.slice(last, m.index)
-    let i = m.index + m[0].length
-    const stack: string[] = []
+  while (i < s.length) {
+    const c = s[i]!
 
-    while (i < s.length) {
-      const c = s[i]
-      if (c === '{' || c === '<' || c === '(') { stack.push(c === '{' ? '}' : c === '<' ? '>' : ')'); i++ }
-      else if (c === '[' && s[i + 1] === ']') { i += 2 }
-      else if (c === '[') { stack.push(']'); i++ }
-      else if (stack.length && c === stack[stack.length - 1]) { stack.pop(); i++; while (s[i] === '[' && s[i + 1] === ']') i += 2 }
-      else if (!stack.length && (c === ',' || c === '\n' || c === '}')) break
-      else i++
+    // Skip string literals — quoted content cannot contain a cast.
+    if (c === '"' || c === "'" || c === '`') {
+      const start = i
+      const quote = c
+      i++
+      while (i < s.length) {
+        const ch = s[i]!
+        if (ch === '\\') { i += 2; continue }
+        if (ch === quote) { i++; break }
+        if (quote === '`' && ch === '$' && s[i + 1] === '{') {
+          // Skip ${...} expression inside template literal (balanced braces).
+          i += 2
+          let depth = 1
+          while (i < s.length && depth > 0) {
+            const e = s[i]!
+            if (e === '{') depth++
+            else if (e === '}') depth--
+            i++
+          }
+          continue
+        }
+        i++
+      }
+      out += s.slice(start, i)
+      continue
     }
-    last = i
+
+    // Skip // line comments
+    if (c === '/' && s[i + 1] === '/') {
+      const start = i
+      while (i < s.length && s[i] !== '\n') i++
+      out += s.slice(start, i)
+      continue
+    }
+
+    // Skip /* block comments */
+    if (c === '/' && s[i + 1] === '*') {
+      const start = i
+      i += 2
+      while (i < s.length && !(s[i] === '*' && s[i + 1] === '/')) i++
+      i += 2
+      out += s.slice(start, i)
+      continue
+    }
+
+    // Detect ` as ` (with surrounding whitespace) at the current position.
+    // Whitespace on both sides guarantees `as` is a standalone token — it
+    // cannot be a substring of an identifier like `class` or `wasnt`.
+    if (/\s/.test(c) && s.startsWith('as', i + 1) && /\s/.test(s[i + 3] ?? '')) {
+      i += 4 // consume ` as `
+      const stack: string[] = []
+      while (i < s.length) {
+        const cc = s[i]!
+        // Strings inside the type cast (rare, e.g. `as 'literal'`) must be skipped too.
+        if (cc === '"' || cc === "'" || cc === '`') {
+          const q = cc
+          i++
+          while (i < s.length) {
+            if (s[i] === '\\') { i += 2; continue }
+            if (s[i] === q) { i++; break }
+            i++
+          }
+          continue
+        }
+        if (cc === '{' || cc === '<' || cc === '(') { stack.push(cc === '{' ? '}' : cc === '<' ? '>' : ')'); i++ }
+        else if (cc === '[' && s[i + 1] === ']') { i += 2 }
+        else if (cc === '[') { stack.push(']'); i++ }
+        else if (stack.length && cc === stack[stack.length - 1]) { stack.pop(); i++; while (s[i] === '[' && s[i + 1] === ']') i += 2 }
+        else if (!stack.length && (cc === ',' || cc === '\n' || cc === '}')) break
+        else i++
+      }
+      continue
+    }
+
+    out += c
+    i++
   }
 
-  return out + s.slice(last)
+  return out
 }
 
 // ===== Component Discovery & Code Generation =====
@@ -239,6 +307,10 @@ function buildStub(metas: ComponentMeta[]): string {
     `}`
   ).join('\n\n')
 }
+
+// ===== Internals exposed for testing =====
+// Not part of the public API. Subject to change without notice.
+export const _internals = { extractMeta, extractDefaultState, stripAsCasts, buildStub }
 
 // ===== Plugin =====
 

--- a/packages/core/src/component/ComponentRegistry.ts
+++ b/packages/core/src/component/ComponentRegistry.ts
@@ -658,9 +658,59 @@ export class ComponentRegistry {
     return await component.executeAction?.(action, payload)
   }
 
+  /**
+   * Apply a client-driven property update to a mounted component.
+   *
+   * Security: the property name is attacker-controlled. We MUST restrict
+   * which keys the client can write, otherwise a malicious frame like
+   *   { type: 'PROPERTY_UPDATE', property: 'session', payload: { value: { roles: ['admin'] } } }
+   * would inject arbitrary fields into `this.state`, polluting reads from
+   * `this.state.session` in subsequent action handlers (CVE-class issue).
+   *
+   * Three rules, evaluated in order:
+   *   1. Prototype-pollution keys (`__proto__`, `constructor`, `prototype`)
+   *      are ALWAYS rejected.
+   *   2. `$`-prefixed keys are server-only by convention — the client cannot
+   *      write them via PROPERTY_UPDATE. The server can still mutate them
+   *      via `this.setState({ $x: ... })` since that bypasses this path.
+   *   3. The key must be in EITHER `static updatableFields` (explicit
+   *      allowlist, takes precedence) OR `static defaultState` (default).
+   */
   updateProperty(componentId: string, property: string, value: any) {
     const component = this.components.get(componentId)
     if (!component) throw new Error(`Component '${componentId}' not found`)
+
+    // (1) Prototype-pollution defense — always rejected.
+    if (property === '__proto__' || property === 'constructor' || property === 'prototype') {
+      throw new Error(`PROPERTY_UPDATE rejected: '${property}' is a reserved key`)
+    }
+
+    // (2) `$`-prefix convention — server-only fields.
+    if (property.startsWith('$')) {
+      throw new Error(
+        `PROPERTY_UPDATE rejected: '${property}' is server-only ` +
+        `($-prefixed fields cannot be written by the client). ` +
+        `Use a server action to mutate it.`
+      )
+    }
+
+    // (3) Allowlist check.
+    const componentClass = component.constructor as any
+    const explicit = componentClass.updatableFields as readonly string[] | undefined
+    const defaults = componentClass.defaultState
+      ? Object.keys(componentClass.defaultState as Record<string, unknown>)
+      : []
+    const allowed = explicit ?? defaults
+
+    if (!allowed.includes(property)) {
+      throw new Error(
+        `PROPERTY_UPDATE rejected: '${property}' is not an updatable field of ` +
+        `'${componentClass.componentName || componentClass.name}'. ` +
+        `Allowed: [${allowed.join(', ')}]. ` +
+        `Declare it in 'static defaultState' or 'static updatableFields' to allow client writes.`
+      )
+    }
+
     component.setState?.({ [property]: value })
   }
 

--- a/packages/core/src/rooms/LiveRoom.ts
+++ b/packages/core/src/rooms/LiveRoom.ts
@@ -13,23 +13,58 @@
 
 import type { LiveRoomManagerInterface } from '../component/context'
 import type { RoomCodecOption } from './RoomCodec'
+import type { LiveAuthSession } from '../auth/types'
 
 // ===== Lifecycle Context Types =====
 
-export interface RoomJoinContext {
+export interface RoomJoinContext<TMembership = any> {
   componentId: string
+  /**
+   * Full auth session of the joining peer (when authenticated). Generic by
+   * design — only `id` is fixed; any field on `LiveAuthSession` can be a
+   * user, bot, device, service, etc. depending on the auth provider.
+   * Frozen — do not mutate; use `membership` for per-member state.
+   */
+  session?: LiveAuthSession
+  /** @deprecated Use `session?.id`. Kept for backwards compatibility. */
   userId?: string
   payload?: any
+  /**
+   * Per-member, server-only metadata bag. Mutate freely from `onJoin`
+   * (e.g. `ctx.membership.playerId = payload.playerId`); the same object
+   * is handed back to `onLeave` so domain code can clean up state keyed
+   * by app-specific identifiers (#36).
+   *
+   * Lives only inside the room — never sent to clients.
+   */
+  membership: TMembership
 }
 
-export interface RoomLeaveContext {
+export interface RoomLeaveContext<TMembership = any> {
   componentId: string
+  /**
+   * Full auth session captured at join time. See `RoomJoinContext.session`.
+   */
+  session?: LiveAuthSession
+  /** @deprecated Use `session?.id`. Kept for backwards compatibility. */
   userId?: string
   reason: 'leave' | 'disconnect' | 'cleanup'
+  /**
+   * The membership bag populated during `onJoin`. Use this to find and
+   * remove entries from `room.state` that are keyed by an app-specific id
+   * rather than the framework's `componentId` (#36).
+   *
+   * Always defined (defaults to an empty object) so consumers can read
+   * fields without nil-checking the whole object.
+   */
+  membership: TMembership
 }
 
 export interface RoomEventContext {
   componentId: string
+  /** Full auth session of the emitter, when authenticated. */
+  session?: LiveAuthSession
+  /** @deprecated Use `session?.id`. Kept for backwards compatibility. */
   userId?: string
 }
 

--- a/packages/core/src/rooms/LiveRoomManager.ts
+++ b/packages/core/src/rooms/LiveRoomManager.ts
@@ -11,6 +11,7 @@ import type { IRoomPubSubAdapter } from './adapters'
 import { computeDeepDiff, deepAssign } from '../utils/deepDiff'
 import type { LiveRoom } from './LiveRoom'
 import type { RoomRegistry } from './RoomRegistry'
+import type { LiveAuthSession } from '../auth/types'
 import {
   resolveCodec,
   buildRoomFrameTail,
@@ -34,6 +35,24 @@ interface RoomMember {
   componentId: string
   ws: GenericWebSocket
   joinedAt: number
+  /**
+   * Full auth session captured at join time. Surfaced back in onLeave so
+   * room cleanup can read any provider-defined field (user/bot/device id,
+   * roles, etc.) even on abrupt disconnect.
+   */
+  session?: LiveAuthSession
+  /**
+   * Resolved id used for onLeave's deprecated `userId` field. Preferred
+   * source is `session.id`; falls back to an explicit `joinContext.userId`
+   * when callers haven't migrated to passing session yet.
+   */
+  userId?: string
+  /**
+   * Per-member, server-only metadata. Populated by `LiveRoom.onJoin` and
+   * passed back to `onLeave` so domain code can clean up `room.state`
+   * entries keyed by app-specific ids (#36).
+   */
+  membership: Record<string, any>
 }
 
 interface Room<TState = any> {
@@ -87,7 +106,7 @@ export class LiveRoomManager {
     ws: GenericWebSocket,
     initialState?: TState,
     options?: { deepDiff?: boolean; deepDiffDepth?: number; serverOnlyState?: boolean },
-    joinContext?: { userId?: string; payload?: any },
+    joinContext?: { userId?: string; session?: LiveAuthSession; payload?: any },
   ): Promise<{ state: TState; rejected?: false } | { rejected: true; reason: string }> {
     // Validate room name format (uses pre-compiled regex from constants)
     if (!roomId || !ROOM_NAME_REGEX.test(roomId)) {
@@ -170,13 +189,25 @@ export class LiveRoomManager {
     // Call onJoin lifecycle hook for LiveRoom-backed rooms. Isolated so a
     // broken onJoin cannot leak an exception out of joinRoom either — we
     // treat throws as an implicit rejection (same path as result === false).
+    //
+    // The `membership` bag is created here, threaded into the hook, and
+    // attached to the RoomMember entry below — so onLeave gets it back even
+    // on abrupt disconnects when only `componentId` is known (#36).
+    const membership: Record<string, any> = {}
+    // Resolve session: prefer explicit joinContext.session, fall back to
+    // ws.data.authContext.session for callers that haven't been updated yet.
+    const session = joinContext?.session
+      ?? (ws as any)?.data?.authContext?.session
+    const resolvedUserId = joinContext?.userId ?? session?.id
     if (room.instance) {
       let joinResult: void | false
       try {
         joinResult = await room.instance.onJoin({
           componentId,
-          userId: joinContext?.userId,
+          session,
+          userId: resolvedUserId,
           payload: joinContext?.payload,
+          membership,
         })
       } catch (err: any) {
         liveWarn('rooms', componentId, `Room '${roomId}' onJoin threw: ${err?.message || err}`)
@@ -196,11 +227,14 @@ export class LiveRoomManager {
       }
     }
 
-    // Add member
+    // Add member (carry the onJoin-populated membership bag for onLeave).
     room.members.set(componentId, {
       componentId,
       ws,
-      joinedAt: now
+      joinedAt: now,
+      session,
+      userId: resolvedUserId,
+      membership,
     })
     room.lastActivity = now
 
@@ -246,10 +280,14 @@ export class LiveRoomManager {
     // Fixes #5 H6: isolate throws so a broken hook cannot prevent member removal
     // and the downstream broadcasts below.
     if (room.instance) {
+      const memberEntry = room.members.get(componentId)
       try {
         await room.instance.onLeave({
           componentId,
+          session: memberEntry?.session,
+          userId: memberEntry?.userId,
           reason: leaveReason,
+          membership: memberEntry?.membership ?? {},
         })
       } catch (err: any) {
         liveWarn('rooms', componentId, `Room '${roomId}' onLeave threw: ${err?.message || err}. Continuing with cleanup.`)
@@ -344,10 +382,14 @@ export class LiveRoomManager {
       // room and componentRooms.delete() at the end of this method would
       // never execute, leaking memory and missing leave notifications.
       if (room.instance) {
+        const memberEntry = room.members.get(componentId)
         try {
           await room.instance.onLeave({
             componentId,
+            session: memberEntry?.session,
+            userId: memberEntry?.userId,
             reason: 'disconnect',
+            membership: memberEntry?.membership ?? {},
           })
         } catch (err: any) {
           liveWarn('rooms', componentId, `Room '${roomId}' onLeave threw during cleanup: ${err?.message || err}. Continuing with remaining rooms.`)
@@ -436,6 +478,37 @@ export class LiveRoomManager {
       data,
       timestamp: now
     }, excludeComponentId)
+  }
+
+  /**
+   * Strip keys that the client is never allowed to set on room state:
+   *   - prototype-pollution keys (`__proto__`, `constructor`, `prototype`)
+   *   - `$`-prefixed keys (server-only convention, mirrors PROPERTY_UPDATE rule)
+   *
+   * Returns a NEW shallow object so the original payload is untouched.
+   * Server-side callers bypass this filter by calling setRoomState directly.
+   */
+  private filterClientRoomStateKeys(updates: any): Record<string, unknown> {
+    if (updates === null || typeof updates !== 'object') return {}
+    const safe: Record<string, unknown> = {}
+    for (const key of Object.keys(updates)) {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue
+      if (key.startsWith('$')) continue
+      safe[key] = updates[key]
+    }
+    return safe
+  }
+
+  /**
+   * Client-driven variant of setRoomState. Filters out keys the client must
+   * never write (prototype-pollution + `$`-prefix) before delegating to the
+   * normal setRoomState. Use this on the path that processes ROOM_STATE_SET
+   * messages — server-internal callers should keep using setRoomState
+   * directly so they retain full authority over the state shape.
+   */
+  setRoomStateFromClient(roomId: string, updates: any, excludeComponentId?: string): void {
+    const safe = this.filterClientRoomStateKeys(updates)
+    this.setRoomState(roomId, safe, excludeComponentId)
   }
 
   /**

--- a/packages/core/src/server/LiveServer.ts
+++ b/packages/core/src/server/LiveServer.ts
@@ -534,7 +534,9 @@ export class LiveServer {
           }))
           break
         }
-        this.roomManager.setRoomState(roomId, message.payload?.state, componentId)
+        // Use the client-facing variant: filters $-prefix + prototype-pollution
+        // keys so the client can't inject server-only fields into shared room state.
+        this.roomManager.setRoomStateFromClient(roomId, message.payload?.state, componentId)
         break
       }
       case 'ROOM_STATE_GET': {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -82,7 +82,10 @@ const component = Live.use<MyComponent>('MyComponent', {
 component.$state.count
 
 // Connection & loading status
-component.$connected
+component.$connected   // WebSocket open?         (transport-level)
+component.$ready       // WebSocket open AND      (use this to gate actions)
+                       // server-side mount done
+component.$status      // detailed lifecycle phase
 component.$loading
 component.$error
 
@@ -91,14 +94,55 @@ await component.increment()
 await component.sendMessage({ text: 'Hello' })
 ```
 
+### Wait for `$ready` before calling actions
+
+`$connected` reflects only the underlying WebSocket. Live Components have a
+**second lifecycle step** — the server has to create the component instance
+and respond with its `componentId` — that runs **after** the WebSocket
+opens. Between those two events there's a brief window where `$connected`
+is already `true` but the component isn't mounted yet, and any action call
+will throw.
+
+```tsx
+// ❌ wrong — racy: actions fire during the "mounting" window
+useEffect(() => {
+  if (!hunt.$connected) return
+  hunt.move({ lat, lng })   // → "component not mounted yet"
+}, [hunt.$connected])
+
+// ✅ correct — waits until the server-side mount completes
+useEffect(() => {
+  if (!hunt.$ready) return
+  hunt.move({ lat, lng })
+}, [hunt.$ready])
+```
+
+`$ready` is `true` iff `$status === 'synced'`. The full status progression:
+
+| `$status`        | meaning                                                |
+|------------------|--------------------------------------------------------|
+| `connecting`     | WebSocket still opening (or down)                      |
+| `reconnecting`   | WebSocket open; restoring state from before disconnect |
+| `loading`        | mount request in flight                                |
+| `mounting`       | WebSocket open, waiting for the server `componentId`   |
+| `error`          | mount failed                                           |
+| `synced`         | **`$ready === true`** — safe to call actions           |
+
+If you call an action before `$ready`, the error message distinguishes the
+two failure modes (`WebSocket is not connected` vs `component '<name>' is
+not mounted yet`) so you can tell which signal to wait on.
+
 ### `useLiveComponent(name, options?)`
 
 Hook equivalent of `Live.use()`:
 
 ```tsx
-const { $state, $connected, call } = useLiveComponent('Counter', {
+const { $state, $ready, call } = useLiveComponent('Counter', {
   defaultState: { count: 0 },
 })
+
+if (!$ready) return <Spinner />     // gate actions on $ready, not $connected
+await call('increment')
 ```
 
 ### `$field(name, options?)`

--- a/packages/react/src/LiveComponentsProvider.tsx
+++ b/packages/react/src/LiveComponentsProvider.tsx
@@ -6,6 +6,7 @@
 import React, { createContext, useContext, useEffect, useRef, useState, useCallback } from 'react'
 import type { LiveAuthOptions, LiveConnectionOptions, LiveClientAuth } from '@fluxstack/live-client'
 import type { WebSocketMessage, WebSocketResponse } from '@fluxstack/live'
+import { acquire as poolAcquire, release as poolRelease, poolKey } from './connectionPool'
 
 export interface LiveComponentsContextValue {
   connected: boolean
@@ -76,10 +77,18 @@ export function LiveComponentsProvider({
     let localUnsub: (() => void) | null = null
     let localLoadCleanup: (() => void) | null = null
 
+    const key = poolKey({ url, auth })
+    let acquired = false
+
     import('@fluxstack/live-client').then(({ LiveConnection }) => {
       if (cancelled) return
 
-      const conn = new LiveConnection({
+      // Pool the connection so React StrictMode's mount → unmount → remount
+      // cycle reuses the same socket instead of opening two simultaneous
+      // handshakes (#34). The pool keeps the connection alive for a short
+      // grace window after release(), which covers StrictMode's sequential
+      // remount.
+      const conn = poolAcquire(key, () => new LiveConnection({
         url,
         auth,
         autoConnect: false,
@@ -87,7 +96,8 @@ export function LiveComponentsProvider({
         maxReconnectAttempts,
         heartbeatInterval,
         debug,
-      })
+      }))
+      acquired = true
 
       localConn = conn
       connectionRef.current = conn
@@ -113,6 +123,9 @@ export function LiveComponentsProvider({
         // Wait for DOM to be fully loaded before connecting.
         // This prevents the WS handshake from competing with
         // initial resource loading (scripts, styles, images).
+        // Calling connect() on an already-connected pooled connection is a
+        // no-op (LiveConnection guards readyState), so this is safe to run
+        // for every acquire().
         if (typeof document !== 'undefined' && document.readyState === 'complete') {
           conn.connect()
         } else if (typeof window !== 'undefined') {
@@ -129,7 +142,9 @@ export function LiveComponentsProvider({
       cancelled = true
       if (localUnsub) localUnsub()
       if (localLoadCleanup) localLoadCleanup()
-      if (localConn) localConn.disconnect()
+      // Release the pooled connection. The pool handles the actual
+      // disconnect after a short grace window — see connectionPool.ts.
+      if (acquired) poolRelease(key)
       if (connectionRef.current === localConn) connectionRef.current = null
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps

--- a/packages/react/src/__tests__/connectionPool-auth.test.ts
+++ b/packages/react/src/__tests__/connectionPool-auth.test.ts
@@ -1,0 +1,121 @@
+// Auth × connection pool (#34) — verifies that the pool's key composition
+// keeps connections with different credentials isolated, while keeping
+// connections with the same credentials shared.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  acquire,
+  release,
+  poolKey,
+  _resetPool,
+  _poolSize,
+} from '../connectionPool'
+
+class FakeConn {
+  static instances = 0
+  id = ++FakeConn.instances
+  disconnected = false
+  disconnect() { this.disconnected = true }
+}
+
+beforeEach(() => {
+  _resetPool()
+  FakeConn.instances = 0
+  vi.useFakeTimers()
+})
+
+describe('connection pool × auth (#34)', () => {
+  it('different tokens on the same URL produce different connections', () => {
+    const kA = poolKey({ url: 'ws://x', auth: { token: 'alice' } as any })
+    const kB = poolKey({ url: 'ws://x', auth: { token: 'bob' } as any })
+    expect(kA).not.toBe(kB)
+
+    const cA = acquire(kA, () => new FakeConn() as any)
+    const cB = acquire(kB, () => new FakeConn() as any)
+    expect(cA).not.toBe(cB)
+    expect(_poolSize()).toBe(2)
+  })
+
+  it('anonymous (auth=null) and authenticated produce different connections', () => {
+    const kAnon = poolKey({ url: 'ws://x' })
+    const kAuth = poolKey({ url: 'ws://x', auth: { token: 'x' } as any })
+    expect(kAnon).not.toBe(kAuth)
+  })
+
+  it('auth=undefined and auth=null map to the same key (both anonymous)', () => {
+    expect(poolKey({ url: 'ws://x', auth: undefined }))
+      .toBe(poolKey({ url: 'ws://x', auth: null as any }))
+  })
+
+  it('same token on the same URL reuses the connection (refcount bumped)', () => {
+    const k = poolKey({ url: 'ws://x', auth: { token: 'alice' } as any })
+    const c1 = acquire(k, () => new FakeConn() as any)
+    const c2 = acquire(k, () => new FakeConn() as any)
+    expect(c2).toBe(c1)
+    expect(FakeConn.instances).toBe(1)
+  })
+
+  it('logout (acquire + release on token, then acquire anonymous) yields a different connection', () => {
+    const kAuth = poolKey({ url: 'ws://x', auth: { token: 'alice' } as any })
+    const kAnon = poolKey({ url: 'ws://x' })
+
+    const cAuth = acquire(kAuth, () => new FakeConn() as any) as unknown as FakeConn
+    release(kAuth) // logout — refcount drops; grace timer arms
+
+    // Switching to anonymous immediately uses a DIFFERENT pool key:
+    const cAnon = acquire(kAnon, () => new FakeConn() as any) as unknown as FakeConn
+    expect(cAnon).not.toBe(cAuth as any)
+
+    // The old (auth) connection is disposed after grace, untouched by anon traffic.
+    vi.advanceTimersByTime(100)
+    expect(cAuth.disconnected).toBe(true)
+    expect(cAnon.disconnected).toBe(false)
+  })
+
+  it('changing token while a previous connection is still alive isolates new socket', () => {
+    const k1 = poolKey({ url: 'ws://x', auth: { token: 't1' } as any })
+    const k2 = poolKey({ url: 'ws://x', auth: { token: 't2' } as any })
+
+    const c1 = acquire(k1, () => new FakeConn() as any) as unknown as FakeConn
+    // User stays "logged in" with t1 (don't release) while another part of
+    // the app authenticates with t2 — both should coexist.
+    const c2 = acquire(k2, () => new FakeConn() as any) as unknown as FakeConn
+
+    expect(c1).not.toBe(c2 as any)
+    expect(_poolSize()).toBe(2)
+    expect(c1.disconnected).toBe(false)
+    expect(c2.disconnected).toBe(false)
+  })
+
+  it('crypto-auth-style credentials (publicKey + signature + nonce) keys correctly', () => {
+    const a = poolKey({ url: 'ws://x', auth: { publicKey: 'PK1', signature: 'sig1', nonce: 'n1' } as any })
+    const b = poolKey({ url: 'ws://x', auth: { publicKey: 'PK2', signature: 'sig2', nonce: 'n2' } as any })
+    expect(a).not.toBe(b)
+
+    // Same publicKey but different nonce → still different key (signatures
+    // and nonces change every handshake; pool intentionally treats them
+    // as distinct credentials).
+    const c = poolKey({ url: 'ws://x', auth: { publicKey: 'PK1', signature: 'sig1', nonce: 'n1' } as any })
+    const d = poolKey({ url: 'ws://x', auth: { publicKey: 'PK1', signature: 'sig1', nonce: 'n2' } as any })
+    expect(c).not.toBe(d)
+  })
+
+  it('order of keys in auth object affects key (JSON.stringify is not order-stable)', () => {
+    // This is a known limitation — documenting it as expected behaviour.
+    // Consumers must produce stable key ordering if they want sharing.
+    const k1 = poolKey({ url: 'ws://x', auth: { token: 't', provider: 'jwt' } as any })
+    const k2 = poolKey({ url: 'ws://x', auth: { provider: 'jwt', token: 't' } as any })
+    // V8 preserves insertion order, so these CAN differ:
+    if (k1 !== k2) {
+      expect(k1).not.toBe(k2)
+    } else {
+      expect(k1).toBe(k2)
+    }
+  })
+
+  it('circular auth object does not throw', () => {
+    const circular: any = { token: 'a' }
+    circular.self = circular
+    expect(() => poolKey({ url: 'ws://x', auth: circular })).not.toThrow()
+  })
+})

--- a/packages/react/src/__tests__/connectionPool-edge.test.ts
+++ b/packages/react/src/__tests__/connectionPool-edge.test.ts
@@ -1,0 +1,165 @@
+// Edge-case coverage for the connection pool (issue #34).
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  acquire,
+  release,
+  poolKey,
+  _resetPool,
+  _poolSize,
+  _refcount,
+} from '../connectionPool'
+
+class FakeConn {
+  static instances = 0
+  id = ++FakeConn.instances
+  disconnected = false
+  disconnect() { this.disconnected = true }
+}
+
+beforeEach(() => {
+  _resetPool()
+  FakeConn.instances = 0
+  vi.useFakeTimers()
+})
+
+describe('connection pool — concurrency (#34)', () => {
+  it('handles many sequential mount/unmount cycles without leaks', () => {
+    const key = poolKey({ url: 'ws://x/ws' })
+    const created: FakeConn[] = []
+
+    for (let i = 0; i < 50; i++) {
+      const c = acquire(key, () => {
+        const conn = new FakeConn()
+        created.push(conn)
+        return conn as any
+      }) as unknown as FakeConn
+      // Release immediately, then re-acquire within grace — should reuse.
+      release(key)
+      const c2 = acquire(key, () => new FakeConn() as any) as unknown as FakeConn
+      expect(c2).toBe(c)
+      release(key) // balance the second acquire
+      release(key) // balance the first
+    }
+
+    expect(FakeConn.instances).toBe(1) // single instance kept alive the whole time
+    expect(_refcount(key)).toBe(0)
+    vi.advanceTimersByTime(1000)
+    expect(_poolSize()).toBe(0)
+    expect(created[0]!.disconnected).toBe(true)
+  })
+
+  it('creates a fresh connection after grace window expires', () => {
+    const key = poolKey({ url: 'ws://x/ws' })
+    const c1 = acquire(key, () => new FakeConn() as any) as unknown as FakeConn
+    release(key)
+    vi.advanceTimersByTime(100) // past grace window
+
+    const c2 = acquire(key, () => new FakeConn() as any) as unknown as FakeConn
+    expect(c2).not.toBe(c1)
+    expect(c1.disconnected).toBe(true)
+    expect(FakeConn.instances).toBe(2)
+  })
+
+  it('handles 3-deep refcount (multiple Providers same url) without disposing', () => {
+    const key = poolKey({ url: 'ws://x/ws' })
+    const c1 = acquire(key, () => new FakeConn() as any) as unknown as FakeConn
+    acquire(key, () => new FakeConn() as any)
+    acquire(key, () => new FakeConn() as any)
+    expect(_refcount(key)).toBe(3)
+
+    release(key)
+    expect(_refcount(key)).toBe(2)
+    release(key)
+    expect(_refcount(key)).toBe(1)
+    // Still alive — last release is the only one that arms the grace timer.
+    vi.advanceTimersByTime(1000)
+    expect(c1.disconnected).toBe(false)
+    expect(_refcount(key)).toBe(1)
+  })
+
+  it('refcount cannot go negative on over-release', () => {
+    const key = poolKey({ url: 'ws://x/ws' })
+    acquire(key, () => new FakeConn() as any)
+    release(key)
+    release(key) // extra
+    release(key) // extra
+    expect(_refcount(key)).toBe(0)
+  })
+
+  it('disconnect throw is swallowed (does not crash the pool)', () => {
+    const key = poolKey({ url: 'ws://x/ws' })
+    class BadConn { disconnect() { throw new Error('boom') } }
+    acquire(key, () => new BadConn() as any)
+    release(key)
+    expect(() => vi.advanceTimersByTime(100)).not.toThrow()
+    expect(_poolSize()).toBe(0)
+  })
+
+  it('release returned canceller stops disposal when invoked', () => {
+    const key = poolKey({ url: 'ws://x/ws' })
+    const c = acquire(key, () => new FakeConn() as any) as unknown as FakeConn
+    const cancel = release(key)
+    cancel()
+    vi.advanceTimersByTime(1000)
+    expect(c.disconnected).toBe(false)
+    expect(_poolSize()).toBe(1)
+  })
+
+  it('cancelling already-fired release is a no-op', () => {
+    const key = poolKey({ url: 'ws://x/ws' })
+    acquire(key, () => new FakeConn() as any)
+    const cancel = release(key)
+    vi.advanceTimersByTime(100) // fire
+    expect(() => cancel()).not.toThrow()
+  })
+})
+
+describe('connection pool — key composition (#34)', () => {
+  it('null/undefined auth maps to the same key', () => {
+    expect(poolKey({ url: 'ws://x' })).toBe(poolKey({ url: 'ws://x', auth: undefined }))
+  })
+
+  it('produces a stable string', () => {
+    const k = poolKey({ url: 'ws://x', auth: { token: 'a' } as any })
+    expect(typeof k).toBe('string')
+    expect(k).toContain('ws://x')
+  })
+
+  it('handles unserializable auth without throwing', () => {
+    const circular: any = {}
+    circular.self = circular
+    expect(() => poolKey({ url: 'ws://x', auth: circular })).not.toThrow()
+  })
+
+  it('different urls are isolated even when one of them has the same auth', () => {
+    const auth = { token: 'shared' } as any
+    expect(poolKey({ url: 'ws://a', auth })).not.toBe(poolKey({ url: 'ws://b', auth }))
+  })
+})
+
+describe('connection pool — issue #34 simulation', () => {
+  it('reproduces StrictMode mount → cleanup → mount and verifies one socket', () => {
+    const key = poolKey({ url: 'ws://localhost/api/live/ws' })
+
+    // First mount (StrictMode synthetic)
+    const c1 = acquire(key, () => new FakeConn() as any)
+    // First cleanup (StrictMode synthetic)
+    release(key)
+    // Second mount (the real one) — happens within microtasks, well inside grace
+    const c2 = acquire(key, () => new FakeConn() as any)
+    // No timer has fired yet — confirm identity:
+    expect(c2).toBe(c1)
+    expect(FakeConn.instances).toBe(1)
+
+    // Even after a long time, while the component is mounted there's no disposal:
+    vi.advanceTimersByTime(10_000)
+    expect((c1 as any).disconnected).toBe(false)
+
+    // Real unmount → after grace, dispose:
+    release(key)
+    vi.advanceTimersByTime(100)
+    expect((c1 as any).disconnected).toBe(true)
+    expect(_poolSize()).toBe(0)
+  })
+})

--- a/packages/react/src/__tests__/connectionPool.test.ts
+++ b/packages/react/src/__tests__/connectionPool.test.ts
@@ -1,0 +1,94 @@
+// Tests for the connection pool that backs LiveComponentsProvider (#34).
+// We use a fake LiveConnection — the pool's contract is "give me back the
+// same instance for the same key, and dispose only after a grace window".
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  acquire,
+  release,
+  poolKey,
+  _resetPool,
+  _poolSize,
+  _refcount,
+} from '../connectionPool'
+
+class FakeConn {
+  static instances = 0
+  id = ++FakeConn.instances
+  disconnected = false
+  disconnect() { this.disconnected = true }
+}
+
+beforeEach(() => {
+  _resetPool()
+  FakeConn.instances = 0
+  vi.useFakeTimers()
+})
+
+describe('connection pool (#34)', () => {
+  it('returns the same connection for the same key on repeat acquire', () => {
+    const key = poolKey({ url: 'ws://x/ws' })
+    const a = acquire(key, () => new FakeConn() as any)
+    const b = acquire(key, () => new FakeConn() as any)
+    expect(a).toBe(b)
+    expect(_refcount(key)).toBe(2)
+  })
+
+  it('different keys produce different connections', () => {
+    const a = acquire(poolKey({ url: 'ws://a/ws' }), () => new FakeConn() as any)
+    const b = acquire(poolKey({ url: 'ws://b/ws' }), () => new FakeConn() as any)
+    expect(a).not.toBe(b)
+    expect(_poolSize()).toBe(2)
+  })
+
+  it('different auth produces a different key', () => {
+    const k1 = poolKey({ url: 'ws://x', auth: { type: 'session', token: 'a' } as any })
+    const k2 = poolKey({ url: 'ws://x', auth: { type: 'session', token: 'b' } as any })
+    expect(k1).not.toBe(k2)
+  })
+
+  it('does NOT disconnect when refcount drops to zero before grace window elapses (StrictMode remount)', () => {
+    const key = poolKey({ url: 'ws://x/ws' })
+    const c1 = acquire(key, () => new FakeConn() as any) as unknown as FakeConn
+
+    // Mount #1 releases (StrictMode's synthetic unmount)…
+    release(key)
+    // …and immediately, before the grace window, mount #2 re-acquires.
+    const c2 = acquire(key, () => new FakeConn() as any) as unknown as FakeConn
+
+    // The grace timer should have been cancelled — same instance, no disconnect.
+    vi.advanceTimersByTime(1000)
+    expect(c2).toBe(c1)
+    expect(c1.disconnected).toBe(false)
+    expect(FakeConn.instances).toBe(1)
+  })
+
+  it('disconnects after the grace window when no one re-acquires', () => {
+    const key = poolKey({ url: 'ws://x/ws' })
+    const c1 = acquire(key, () => new FakeConn() as any) as unknown as FakeConn
+    release(key, 50)
+
+    expect(c1.disconnected).toBe(false)
+    vi.advanceTimersByTime(50)
+    expect(c1.disconnected).toBe(true)
+    expect(_poolSize()).toBe(0)
+  })
+
+  it('does not double-dispose with multiple releases', () => {
+    const key = poolKey({ url: 'ws://x/ws' })
+    const c1 = acquire(key, () => new FakeConn() as any) as unknown as FakeConn
+    acquire(key, () => new FakeConn() as any)
+    expect(_refcount(key)).toBe(2)
+
+    release(key)
+    release(key)
+    expect(_refcount(key)).toBe(0)
+
+    vi.advanceTimersByTime(100)
+    expect(c1.disconnected).toBe(true)
+  })
+
+  it('release returns a no-op for unknown keys', () => {
+    expect(() => release('unknown')()).not.toThrow()
+  })
+})

--- a/packages/react/src/__tests__/proxy-ready.test.ts
+++ b/packages/react/src/__tests__/proxy-ready.test.ts
@@ -1,0 +1,93 @@
+// Tests that pin $ready into the proxy contract (#35).
+//
+// We can't render the hook here — the package has no DOM/react-dom test
+// infra — but we can still lock down three guarantees:
+//
+//   1. $ready appears in the RESERVED_PROPS set (otherwise it would be
+//      interpreted as a server action and any access would fire a CALL_ACTION).
+//   2. The hook source maps $ready to `getStatus() === 'synced'` — and not
+//      something like `connected`, which would re-introduce the #35 bug.
+//   3. $ready appears in the ownKeys list returned by the proxy.
+//
+// These are structural assertions over the implementation file. They protect
+// against silent regressions where someone removes the case from the switch,
+// or rewires it incorrectly, without spinning up React.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { _RESERVED_PROPS } from '../hooks/useLiveComponent'
+
+const HOOK_SRC = readFileSync(
+  join(__dirname, '..', 'hooks', 'useLiveComponent.ts'),
+  'utf-8',
+)
+
+describe('$ready proxy contract (#35)', () => {
+  it('is registered as a reserved prop', () => {
+    expect(_RESERVED_PROPS.has('$ready')).toBe(true)
+  })
+
+  it('is mapped to status === "synced" inside the proxy get handler', () => {
+    // Look for `case '$ready': return ... 'synced'` — the exact mapping that
+    // makes $ready the correct action gate. If someone rewires this to
+    // `connected`, the #35 bug returns and this test fails.
+    const m = HOOK_SRC.match(/case\s+['"]\$ready['"]\s*:\s*return\s+([^\n]+)/)
+    expect(m, 'proxy switch must have a case for $ready').not.toBeNull()
+    const expr = m![1]!
+    expect(expr).toContain("'synced'")
+    expect(expr).toContain('getStatus()')
+  })
+
+  it('appears in the ownKeys list so it is enumerable', () => {
+    // The ownKeys() array literal must include $ready.
+    const ownKeysBlock = HOOK_SRC.match(/ownKeys\(\)\s*\{\s*return\s*\[([\s\S]*?)\]/)
+    expect(ownKeysBlock, 'ownKeys block not found').not.toBeNull()
+    expect(ownKeysBlock![1]).toContain("'$ready'")
+  })
+
+  it('is documented on the LiveComponentProxy interface', () => {
+    // The TS interface that documents the public proxy surface must declare
+    // `readonly $ready: boolean`. Without this, TS apps don't see the prop.
+    expect(HOOK_SRC).toMatch(/readonly\s+\$ready\s*:\s*boolean/)
+  })
+
+  it('docstring on $ready mentions $status === "synced" so devs know the relation', () => {
+    // Pin the documentation that distinguishes $ready from $connected — this
+    // is the educational fix for the #35 confusion.
+    const idx = HOOK_SRC.indexOf('readonly $ready')
+    expect(idx).toBeGreaterThan(0)
+    const preceding = HOOK_SRC.slice(Math.max(0, idx - 1200), idx)
+    expect(preceding).toContain('synced')
+  })
+})
+
+describe('$ready ↔ readiness helper consistency (#35)', () => {
+  // The hook computes $ready via `getStatus() === 'synced'`. The standalone
+  // helper `isReady()` must agree, so any test of one is meaningful for the
+  // other. This is a sanity check that the helper exports exist.
+  it('exports computeStatus and isReady', async () => {
+    const mod = await import('../hooks/readiness')
+    expect(typeof mod.computeStatus).toBe('function')
+    expect(typeof mod.isReady).toBe('function')
+  })
+
+  it('isReady agrees with the "synced" branch of computeStatus', async () => {
+    const { computeStatus, isReady } = await import('../hooks/readiness')
+    const inputs = { connected: true, rehydrating: false, loading: false, error: null, componentId: 'c-1' }
+    expect(computeStatus(inputs)).toBe('synced')
+    expect(isReady(inputs)).toBe(true)
+  })
+
+  it('isReady is false in every non-synced status', async () => {
+    const { isReady } = await import('../hooks/readiness')
+    const cases = [
+      { connected: false, rehydrating: false, loading: false, error: null, componentId: 'c-1' },
+      { connected: true, rehydrating: true, loading: false, error: null, componentId: 'c-1' },
+      { connected: true, rehydrating: false, loading: true, error: null, componentId: 'c-1' },
+      { connected: true, rehydrating: false, loading: false, error: 'x', componentId: 'c-1' },
+      { connected: true, rehydrating: false, loading: false, error: null, componentId: null },
+    ]
+    for (const c of cases) expect(isReady(c)).toBe(false)
+  })
+})

--- a/packages/react/src/__tests__/readiness-auth.test.ts
+++ b/packages/react/src/__tests__/readiness-auth.test.ts
@@ -1,0 +1,88 @@
+// Auth × $ready interaction (#35). The hook keeps auth state separate from
+// the lifecycle status — these tests pin down the expected behaviour so
+// future refactors don't silently re-couple them.
+
+import { describe, it, expect } from 'vitest'
+import { computeStatus, isReady, notReadyError } from '../hooks/readiness'
+
+const base = {
+  connected: false,
+  rehydrating: false,
+  loading: false,
+  error: null as string | null,
+  componentId: null as string | null,
+}
+
+describe('readiness × auth (#35)', () => {
+  it('AUTH_DENIED from server mount sets error → $ready=false, status=error', () => {
+    // The hook's mount() path catches AUTH_DENIED, calls setError, and bails
+    // before setting componentId. From computeStatus' perspective this is
+    // indistinguishable from any other mount failure — and that's correct.
+    const s = { ...base, connected: true, error: 'AUTH_DENIED: roles=admin required' }
+    expect(computeStatus(s)).toBe('error')
+    expect(isReady(s)).toBe(false)
+  })
+
+  it('after authenticate() succeeds, the hook retries mount; $ready stays false during retry', () => {
+    // Phase 1: post-AUTH_DENIED, before retry kicks in.
+    const denied = { ...base, connected: true, error: 'AUTH_DENIED' }
+    expect(isReady(denied)).toBe(false)
+
+    // Phase 2: hook clears error, sets loading=true, sends a new COMPONENT_MOUNT.
+    const retrying = { ...base, connected: true, loading: true, error: null }
+    expect(computeStatus(retrying)).toBe('loading')
+    expect(isReady(retrying)).toBe(false)
+
+    // Phase 3: mount succeeds — componentId arrives, all flags clear.
+    const synced = { ...base, connected: true, componentId: 'c-1' }
+    expect(isReady(synced)).toBe(true)
+  })
+
+  it('anonymous user on a public component reaches $ready normally', () => {
+    // Public components (no `static auth = { required: true }`) don't depend
+    // on $authenticated to mount. The hook should treat them like any other.
+    const s = { ...base, connected: true, componentId: 'c-1' }
+    expect(isReady(s)).toBe(true)
+  })
+
+  it('notReadyError for an action called after AUTH_DENIED says "not mounted", not "not connected"', () => {
+    // WS is up but mount failed → error message must point at the component,
+    // not the websocket, so the developer hunts in the right place.
+    const err = notReadyError('deleteUser', 'AdminPanel', {
+      ...base,
+      connected: true,
+      error: 'AUTH_DENIED',
+    })
+    expect(err.message).toContain('not mounted')
+    expect(err.message).not.toContain('WebSocket is not connected')
+    expect(err.message).toContain('AdminPanel')
+  })
+
+  it('disconnect during an authenticated session → status flips to connecting, ready=false', () => {
+    // User was happily synced; WS dropped (e.g. server restart).
+    // Even though the auth context is still cached, $ready must be false.
+    const wasSynced = { ...base, connected: true, componentId: 'c-1' }
+    expect(isReady(wasSynced)).toBe(true)
+
+    const dropped = { ...wasSynced, connected: false }
+    expect(computeStatus(dropped)).toBe('connecting')
+    expect(isReady(dropped)).toBe(false)
+  })
+
+  it('reconnect with rehydration: rehydrating beats componentId — $ready stays false until done', () => {
+    // After reconnect, the hook may try to restore the prior componentId by
+    // re-mounting on the new socket. While rehydration is in progress, even
+    // though componentId is still set from before, $ready must be false.
+    const rehyd = { ...base, connected: true, rehydrating: true, componentId: 'c-1' }
+    expect(computeStatus(rehyd)).toBe('reconnecting')
+    expect(isReady(rehyd)).toBe(false)
+  })
+
+  it('partial denial path: WS auth fails but mount is public-friendly', () => {
+    // Imagine: server-level auth rejected the token (so $authenticated=false)
+    // but the component itself is public. The hook ignores auth status and
+    // still mounts; $ready=true once componentId arrives.
+    const s = { ...base, connected: true, componentId: 'c-pub' }
+    expect(isReady(s)).toBe(true)
+  })
+})

--- a/packages/react/src/__tests__/readiness.test.ts
+++ b/packages/react/src/__tests__/readiness.test.ts
@@ -1,0 +1,102 @@
+// Tests for the readiness helpers used by useLiveComponent (#35).
+
+import { describe, it, expect } from 'vitest'
+import { computeStatus, isReady, notReadyError } from '../hooks/readiness'
+
+const base = {
+  connected: false,
+  rehydrating: false,
+  loading: false,
+  error: null as string | null,
+  componentId: null as string | null,
+}
+
+describe('computeStatus (#35)', () => {
+  it('reports "connecting" when the WS is down', () => {
+    expect(computeStatus({ ...base, connected: false })).toBe('connecting')
+  })
+
+  it('reports "reconnecting" when rehydrating', () => {
+    expect(computeStatus({ ...base, connected: true, rehydrating: true })).toBe('reconnecting')
+  })
+
+  it('reports "loading" when the component is loading', () => {
+    expect(computeStatus({ ...base, connected: true, loading: true })).toBe('loading')
+  })
+
+  it('reports "error" when an error string is set', () => {
+    expect(computeStatus({ ...base, connected: true, error: 'oops' })).toBe('error')
+  })
+
+  it('reports "mounting" when connected but no componentId yet (the #35 window)', () => {
+    expect(computeStatus({ ...base, connected: true, componentId: null })).toBe('mounting')
+  })
+
+  it('reports "synced" only when connected AND mounted AND idle', () => {
+    expect(computeStatus({ ...base, connected: true, componentId: 'c-1' })).toBe('synced')
+  })
+
+  it('error precedence: rehydrating beats loading', () => {
+    expect(computeStatus({ ...base, connected: true, rehydrating: true, loading: true })).toBe('reconnecting')
+  })
+
+  it('error precedence: loading beats error (loading is an in-flight state)', () => {
+    expect(computeStatus({ ...base, connected: true, loading: true, error: 'x' })).toBe('loading')
+  })
+
+  it('error precedence: disconnected beats everything', () => {
+    expect(computeStatus({ ...base, connected: false, rehydrating: true, loading: true, error: 'x', componentId: 'c-1' })).toBe('connecting')
+  })
+})
+
+describe('isReady (#35)', () => {
+  it('is true only on synced', () => {
+    expect(isReady({ ...base, connected: true, componentId: 'c-1' })).toBe(true)
+  })
+
+  it('is false during the #35 "WS connected but not mounted" window', () => {
+    expect(isReady({ ...base, connected: true, componentId: null })).toBe(false)
+  })
+
+  it('is false while loading', () => {
+    expect(isReady({ ...base, connected: true, componentId: 'c-1', loading: true })).toBe(false)
+  })
+
+  it('is false while disconnected even with a stale componentId', () => {
+    expect(isReady({ ...base, connected: false, componentId: 'c-1' })).toBe(false)
+  })
+})
+
+describe('notReadyError (#35)', () => {
+  it('mentions the action and a status when WS is down', () => {
+    const err = notReadyError('move', 'TrophyHunt', { ...base, connected: false })
+    expect(err.message).toContain(`'move'`)
+    expect(err.message).toContain('WebSocket')
+    expect(err.message).toContain('status=connecting')
+  })
+
+  it('mentions the component name and "not mounted" when WS up but no id', () => {
+    const err = notReadyError('move', 'TrophyHunt', { ...base, connected: true, componentId: null })
+    expect(err.message).toContain(`'TrophyHunt'`)
+    expect(err.message).toContain('not mounted')
+    expect(err.message).toContain('status=mounting')
+  })
+
+  it('directs the developer to wait on $ready', () => {
+    const err = notReadyError('whatever', 'C', { ...base, connected: true, componentId: null })
+    expect(err.message).toContain('$ready')
+  })
+
+  it('returns an Error instance', () => {
+    const err = notReadyError('a', 'C', { ...base })
+    expect(err).toBeInstanceOf(Error)
+  })
+
+  it('uses different wording for WS-down vs not-mounted (covers the #35 confusion)', () => {
+    const down = notReadyError('a', 'C', { ...base, connected: false })
+    const notMounted = notReadyError('a', 'C', { ...base, connected: true, componentId: null })
+    expect(down.message).not.toBe(notMounted.message)
+    expect(down.message).toContain('WebSocket')
+    expect(notMounted.message).toContain('not mounted')
+  })
+})

--- a/packages/react/src/connectionPool.ts
+++ b/packages/react/src/connectionPool.ts
@@ -1,0 +1,122 @@
+// Module-level WebSocket connection pool, shared by all LiveComponentsProvider
+// instances. Solves issue #34: React StrictMode mounts effects twice in dev
+// (mount → cleanup → mount), and the original Provider created two distinct
+// LiveConnection instances — both initiated a WS handshake before the first
+// one could be torn down, leaving the server with two simultaneous sockets
+// per tab.
+//
+// Design:
+//   1. Connections are pooled by a stable key (URL + serialized auth options).
+//   2. Each acquire() bumps a refcount; release() decrements it.
+//   3. When the refcount drops to zero we DON'T disconnect immediately —
+//      a short grace window (default 50 ms) keeps the socket alive so the
+//      StrictMode remount can reuse it. If no one re-acquires within the
+//      window, the connection is closed and removed from the pool.
+//   4. Concurrent acquires for the same key always get the same instance.
+//
+// This module is intentionally framework-agnostic: it does not import React
+// and has no UI side effects, which makes it trivial to test.
+
+import type { LiveConnection, LiveConnectionOptions } from '@fluxstack/live-client'
+
+interface PoolEntry {
+  conn: LiveConnection
+  refcount: number
+  releaseTimer: ReturnType<typeof setTimeout> | null
+}
+
+const pool = new Map<string, PoolEntry>()
+
+/** Grace window before a zero-refcount entry is actually disposed (ms). */
+const DEFAULT_GRACE_MS = 50
+
+/**
+ * Build a pool key from connection options.
+ *
+ * URL is the primary discriminator. We also include a hash of auth so two
+ * Providers with different credentials get separate sockets.
+ */
+export function poolKey(options: Pick<LiveConnectionOptions, 'url' | 'auth'>): string {
+  const url = options.url ?? '<default>'
+  // Stable, cheap hash — JSON.stringify is fine: auth objects are small and
+  // the order of keys is consistent within a single Provider's options.
+  let authStr = ''
+  try { authStr = JSON.stringify(options.auth ?? null) } catch { authStr = '<unserializable>' }
+  return `${url}|${authStr}`
+}
+
+/**
+ * Acquire (or create) a pooled LiveConnection for the given options.
+ *
+ * @param factory - Called only when no live entry exists for `key`. Must
+ *   return a brand new `LiveConnection`. The factory is what binds the
+ *   connection to the specific LiveConnection class — keeping this module
+ *   free of a direct dependency on @fluxstack/live-client (which is a
+ *   dynamic import in the Provider for SSR-safety).
+ */
+export function acquire(
+  key: string,
+  factory: () => LiveConnection,
+): LiveConnection {
+  let entry = pool.get(key)
+  if (entry) {
+    // Cancel any pending disposal: someone is re-acquiring before the grace
+    // window elapsed (this is the StrictMode remount path).
+    if (entry.releaseTimer) {
+      clearTimeout(entry.releaseTimer)
+      entry.releaseTimer = null
+    }
+    entry.refcount++
+    return entry.conn
+  }
+  entry = { conn: factory(), refcount: 1, releaseTimer: null }
+  pool.set(key, entry)
+  return entry.conn
+}
+
+/**
+ * Release a previously-acquired connection. When the refcount reaches zero
+ * the connection is disposed after a short grace period — enough to let a
+ * StrictMode remount happen synchronously without tearing down the socket.
+ *
+ * Returns a function that cancels the pending release (useful when the
+ * caller knows it will re-acquire imminently). The function is idempotent.
+ */
+export function release(key: string, graceMs = DEFAULT_GRACE_MS): () => void {
+  const entry = pool.get(key)
+  if (!entry) return () => {}
+  entry.refcount = Math.max(0, entry.refcount - 1)
+  if (entry.refcount > 0) return () => {}
+
+  // Schedule disposal. If someone acquires the same key before this fires,
+  // acquire() will cancel the timer.
+  entry.releaseTimer = setTimeout(() => {
+    const cur = pool.get(key)
+    if (!cur || cur.refcount > 0) return
+    try { cur.conn.disconnect() } catch { /* ignore */ }
+    pool.delete(key)
+  }, graceMs)
+
+  const timer = entry.releaseTimer
+  return () => {
+    if (entry.releaseTimer === timer) {
+      clearTimeout(timer)
+      entry.releaseTimer = null
+    }
+  }
+}
+
+/** @internal Test helper: drop all pooled entries without grace. */
+export function _resetPool(): void {
+  for (const entry of pool.values()) {
+    if (entry.releaseTimer) clearTimeout(entry.releaseTimer)
+    try { entry.conn.disconnect() } catch { /* ignore */ }
+  }
+  pool.clear()
+}
+
+/** @internal Test helper: inspect pool size. */
+export function _poolSize(): number { return pool.size }
+
+/** @internal Test helper: inspect refcount for a key. */
+export function _refcount(key: string): number { return pool.get(key)?.refcount ?? 0 }

--- a/packages/react/src/hooks/readiness.ts
+++ b/packages/react/src/hooks/readiness.ts
@@ -1,0 +1,70 @@
+// Readiness helpers used by useLiveComponent (issue #35).
+//
+// Extracted from the hook so the gate logic and error messages can be
+// tested in isolation without spinning up React + a WebSocket.
+
+export type LiveStatus =
+  | 'synced'
+  | 'disconnected'
+  | 'connecting'
+  | 'reconnecting'
+  | 'loading'
+  | 'mounting'
+  | 'error'
+
+export interface StatusInputs {
+  connected: boolean
+  rehydrating: boolean
+  loading: boolean
+  error: string | null
+  componentId: string | null
+}
+
+/**
+ * Compute the lifecycle status of a Live component.
+ *
+ * Ordering matters: a disconnected WebSocket is reported as 'connecting'
+ * (covers both initial and reconnect phases — the underlying client emits
+ * 'reconnecting' separately if it's a reconnect), rehydration takes
+ * precedence over loading because the user already had a live component
+ * that's being restored, and a non-null componentId is the final gate
+ * before declaring 'synced'.
+ */
+export function computeStatus(s: StatusInputs): LiveStatus {
+  if (!s.connected) return 'connecting'
+  if (s.rehydrating) return 'reconnecting'
+  if (s.loading) return 'loading'
+  if (s.error) return 'error'
+  if (!s.componentId) return 'mounting'
+  return 'synced'
+}
+
+/** Convenience: `$ready` boolean exposed on the proxy. */
+export function isReady(s: StatusInputs): boolean {
+  return computeStatus(s) === 'synced'
+}
+
+/**
+ * Build a precise "not ready" error for a failed action call.
+ *
+ * Distinguishes the WS-down case (`connected === false`) from the
+ * component-not-mounted case so the developer knows which condition to wait
+ * for. Replaces the old generic "Not connected" message from #35.
+ */
+export function notReadyError(
+  action: string,
+  componentName: string,
+  s: StatusInputs,
+): Error {
+  const status = computeStatus(s)
+  if (!s.connected) {
+    return new Error(
+      `Cannot call '${action}': WebSocket is not connected (status=${status}). ` +
+      `Wait for proxy.$ready before firing actions.`,
+    )
+  }
+  return new Error(
+    `Cannot call '${action}': component '${componentName}' is not mounted yet (status=${status}). ` +
+    `Wait for proxy.$ready before firing actions.`,
+  )
+}

--- a/packages/react/src/hooks/useLiveComponent.ts
+++ b/packages/react/src/hooks/useLiveComponent.ts
@@ -22,6 +22,7 @@ import {
 import type { RoomProxy, RoomServerMessage } from '@fluxstack/live-client'
 import type { WebSocketResponse } from '@fluxstack/live'
 import { generateId } from '@fluxstack/live-client'
+import { computeStatus, notReadyError as makeNotReadyError } from './readiness'
 
 // ===== Deep Merge (always-on, retrocompatible) =====
 
@@ -96,6 +97,16 @@ export interface LiveComponentProxy<
 > {
   readonly $state: TState
   readonly $connected: boolean
+  /**
+   * `true` when the component has finished its server-side mount handshake
+   * and is safe to call actions on (equivalent to `$status === 'synced'`).
+   *
+   * Prefer `$ready` over `$connected` as an action gate: `$connected` only
+   * reflects the underlying WebSocket and may be `true` during the brief
+   * window before the component is mounted on the server — actions fired
+   * in that window will reject with "Component not yet mounted" (#35).
+   */
+  readonly $ready: boolean
   readonly $loading: boolean
   readonly $error: string | null
   readonly $status: 'synced' | 'disconnected' | 'connecting' | 'reconnecting' | 'loading' | 'mounting' | 'error'
@@ -176,12 +187,15 @@ export interface UseLiveComponentOptions extends HybridComponentOptions {
 // ===== Reserved Props =====
 
 const RESERVED_PROPS = new Set([
-  '$state', '$connected', '$loading', '$error', '$status', '$componentId', '$dirty', '$authenticated', '$auth',
+  '$state', '$connected', '$ready', '$loading', '$error', '$status', '$componentId', '$dirty', '$authenticated', '$auth',
   '$call', '$callAndWait', '$fire', '$mount', '$unmount', '$refresh', '$set', '$onBroadcast', '$updateLocal',
   '$room', '$rooms', '$field', '$sync',
   'then', 'toJSON', 'valueOf', 'toString',
   Symbol.toStringTag, Symbol.iterator,
 ])
+
+/** @internal Exposed for tests. Subject to change without notice. */
+export const _RESERVED_PROPS = RESERVED_PROPS
 
 // ===== Zustand Store =====
 
@@ -420,10 +434,15 @@ export function useLiveComponent<
     }
   }, [connected, componentName, sendMessageAndWait, onRehydrate])
 
+  // Build a precise error explaining WHY an action can't run right now.
+  // Differentiates "WebSocket down" from "component not mounted yet" (#35).
+  const notReadyError = (action: string): Error =>
+    makeNotReadyError(action, componentName, { connected, rehydrating, loading, error, componentId })
+
   // ===== Call Action =====
   const call = useCallback(async (action: string, payload?: any) => {
     const id = componentId || lastComponentIdRef.current
-    if (!id || !connected) throw new Error('Not connected')
+    if (!id || !connected) throw notReadyError(action)
 
     const response = await sendMessageAndWait({
       type: 'CALL_ACTION',
@@ -437,7 +456,7 @@ export function useLiveComponent<
 
   const callAndWait = useCallback(async <R = any>(action: string, payload?: any, timeout = 10000): Promise<R> => {
     const id = componentId || lastComponentIdRef.current
-    if (!id || !connected) throw new Error('Not connected')
+    if (!id || !connected) throw notReadyError(action)
 
     const response = await sendMessageAndWait({
       type: 'CALL_ACTION',
@@ -745,14 +764,13 @@ export function useLiveComponent<
   }, [unmount])
 
   // ===== Status =====
-  const getStatus = () => {
-    if (!connected) return 'connecting'
-    if (rehydrating) return 'reconnecting'
-    if (loading) return 'loading'
-    if (error) return 'error'
-    if (!componentId) return 'mounting'
-    return 'synced'
-  }
+  const getStatus = () => computeStatus({
+    connected,
+    rehydrating,
+    loading,
+    error,
+    componentId,
+  })
 
   // ===== Proxy =====
   const proxy = useMemo(() => {
@@ -766,6 +784,7 @@ export function useLiveComponent<
         switch (prop) {
           case '$state': return storeRef.current?.getState().state ?? stateData
           case '$connected': return connected
+          case '$ready': return getStatus() === 'synced'
           case '$loading': return loading
           case '$error': return error
           case '$status': return getStatus()
@@ -808,7 +827,7 @@ export function useLiveComponent<
         // Action (anything not in state or reserved)
         return async (payload?: any) => {
           const id = componentId || lastComponentIdRef.current
-          if (!id || !connected) throw new Error('Not connected')
+          if (!id || !connected) throw notReadyError(prop)
 
           const response = await sendMessageAndWait({
             type: 'CALL_ACTION',
@@ -836,7 +855,7 @@ export function useLiveComponent<
       ownKeys() {
         return [
           ...Object.keys(stateData),
-          '$state', '$connected', '$loading', '$error', '$status', '$componentId', '$dirty', '$authenticated', '$auth',
+          '$state', '$connected', '$ready', '$loading', '$error', '$status', '$componentId', '$dirty', '$authenticated', '$auth',
           '$call', '$callAndWait', '$fire', '$mount', '$unmount', '$refresh', '$set', '$field', '$sync',
           '$onBroadcast', '$updateLocal', '$room', '$rooms',
         ]


### PR DESCRIPTION
## Summary

Fixes the four open bug reports (#33-#36) and tightens two client state-mutation paths that came up during validation.

### Bug fixes

- **#33** — Stub generator stripAsCasts walked source with a global regex and corrupted string literals containing the word `as`. Rewritten as a context-aware scanner that skips strings/templates/comments.
- **#34** — `LiveComponentsProvider` opened two WebSockets per tab under React StrictMode. New module-level connection pool with refcount + 50ms grace window reuses the same socket across mount→cleanup→mount.
- **#35** — Actions called after `$connected=true` but before mount completed threw a generic `'Not connected'`. Adds `proxy.$ready` (alias for `$status === 'synced'`) and distinct error messages for WS-down vs not-mounted.
- **#36** — `RoomLeaveContext` had only `componentId`, so rooms keying state by app id (`state.players[playerId]`) couldn't clean up on abrupt disconnect. Adds `membership` (mutable, server-only, scoped per member) and `session?: LiveAuthSession` (auto-derived from `ws.data.authContext`) to `RoomJoinContext` / `RoomLeaveContext` / `RoomEventContext`. `userId` kept as `@deprecated` alias.

### Security hardening (came up during review)

- **fix(core)!**: `PROPERTY_UPDATE` and `ROOM_STATE_SET` accepted arbitrary keys from the client, letting a forged frame inject `session`/`__proto__`/etc into `this.state`. Validated reproducible in Chrome against the running app. Now enforces three rules: prototype-pollution keys always rejected, `$`-prefixed keys are server-only by convention, and the key must be in `static updatableFields` (explicit) or `static defaultState` (default).
- **fix(client)**: `LiveConnection` mirrored the server session unfrozen. App code doing `proxy.$auth.session.plan = 'enterprise'` silently corrupted the shared reference. Now deep-frozen at all three update points; strict mode throws on mutation.

### Validation

- **1180 tests passing** (Redis included, all 7 packages typecheck and build clean)
- **152 new tests** covering: stub edge cases, pool concurrency + auth scenarios, $ready ↔ status precedence, membership in multi-room cleanup, session shapes for user/bot/device, custom DevAuthProvider session round-trip, PROPERTY_UPDATE/ROOM_STATE_SET injection vectors, session deep-freeze, end-to-end issue reproducers.
- **Manual end-to-end** in FluxStack via Chrome DevTools MCP: StrictMode (5 page loads → 5 handshakes, was 10), login/logout/login with different tokens, AdminPanel with custom session fields (`email`, `plan`, `orgId`, `joinedAt`, `kind`) — all flow intact from `DevAuthProvider.authenticate()` to `this.$auth.session` to the audit log rendered in the DOM.

### Breaking change

Only one: `PROPERTY_UPDATE` no longer accepts undeclared keys. Apps that relied on this (rare, undocumented) need to add the key to `static defaultState` or `static updatableFields`. Hence the `!` on that commit. The rest is additive — `userId` and existing APIs continue to work.

### Commits

1. `fix(core)`: stub generator preserves strings containing 'as' (#33)
2. `fix(react)`: dedupe WebSocket under React StrictMode via connection pool (#34)
3. `fix(react)`: add $ready proxy gate and explicit not-ready error (#35)
4. `feat(core)`: RoomLeaveContext gets membership + session for cleanup (#36)
5. `fix(core)!`: prevent client state injection via PROPERTY_UPDATE and ROOM_STATE_SET
6. `fix(client)`: deep-freeze auth session mirror to fail fast on local mutation
7. `test`: end-to-end reproducers for issues #33–#36

## Test plan

- [x] All unit + integration tests pass (1180 green, Redis included)
- [x] Typecheck clean for core/react/client/elysia/express/fastify/vue/redis
- [x] All 7 packages build with no errors
- [x] Manual validation in real FluxStack app with Chrome DevTools MCP: StrictMode dedup, full login/logout/login flow with role-based access, audit log with custom session fields
- [x] Manual probe confirming the PROPERTY_UPDATE injection is now rejected
- [ ] Reviewer: confirm the `static updatableFields` opt-in is acceptable as the only breaking surface

Closes #33 #34 #35 #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)