### PR TITLE
test: cover 4 untested modules (+91 tests, +1 bug fix)

### DIFF
--- a/packages/client/src/__tests__/persistence.test.ts
+++ b/packages/client/src/__tests__/persistence.test.ts
@@ -1,0 +1,140 @@
+// persistence.ts — localStorage round-trip, TTL expiry, no-op when disabled,
+// quota-exceeded resilience. Zero coverage before this file.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { persistState, getPersistedState, clearPersistedState } from '../persistence'
+
+// jsdom-free mock — vitest does not bring a DOM by default for this package.
+class FakeStorage implements Storage {
+  private store = new Map<string, string>()
+  get length() { return this.store.size }
+  clear() { this.store.clear() }
+  getItem(k: string) { return this.store.get(k) ?? null }
+  key(i: number) { return Array.from(this.store.keys())[i] ?? null }
+  removeItem(k: string) { this.store.delete(k) }
+  setItem(k: string, v: string) { this.store.set(k, v) }
+  /** test helper */
+  _setRaw(k: string, v: string) { this.store.set(k, v) }
+}
+
+class ThrowingStorage implements Storage {
+  length = 0
+  clear() {}
+  getItem() { return null }
+  key() { return null }
+  removeItem() {}
+  setItem() { throw new DOMException('QuotaExceededError', 'QuotaExceededError') }
+}
+
+let fake: FakeStorage
+beforeEach(() => {
+  fake = new FakeStorage()
+  ;(globalThis as any).localStorage = fake
+})
+afterEach(() => {
+  delete (globalThis as any).localStorage
+})
+
+describe('persistState', () => {
+  it('writes a JSON blob to localStorage when enabled', () => {
+    persistState(true, 'Counter', { sig: 'abc', state: { count: 1 } }, 'lobby', 'user-1')
+    const raw = fake.getItem('fluxstack_component_Counter')
+    expect(raw).toBeTruthy()
+    const parsed = JSON.parse(raw!)
+    expect(parsed.componentName).toBe('Counter')
+    expect(parsed.signedState).toEqual({ sig: 'abc', state: { count: 1 } })
+    expect(parsed.room).toBe('lobby')
+    expect(parsed.userId).toBe('user-1')
+    expect(typeof parsed.lastUpdate).toBe('number')
+  })
+
+  it('is a no-op when enabled is false', () => {
+    persistState(false, 'Counter', { x: 1 })
+    expect(fake.getItem('fluxstack_component_Counter')).toBeNull()
+  })
+
+  it('does not throw when localStorage throws (quota exceeded)', () => {
+    ;(globalThis as any).localStorage = new ThrowingStorage()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(() => persistState(true, 'Counter', { x: 1 })).not.toThrow()
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('omits optional room/userId when not provided', () => {
+    persistState(true, 'X', { a: 1 })
+    const parsed = JSON.parse(fake.getItem('fluxstack_component_X')!)
+    expect(parsed.room).toBeUndefined()
+    expect(parsed.userId).toBeUndefined()
+  })
+
+  it('overwrites prior state for the same component name', () => {
+    persistState(true, 'X', { v: 1 })
+    persistState(true, 'X', { v: 2 })
+    const parsed = JSON.parse(fake.getItem('fluxstack_component_X')!)
+    expect(parsed.signedState.v).toBe(2)
+  })
+})
+
+describe('getPersistedState', () => {
+  it('returns null when not enabled', () => {
+    persistState(true, 'X', { v: 1 })
+    expect(getPersistedState(false, 'X')).toBeNull()
+  })
+
+  it('returns null when nothing is stored', () => {
+    expect(getPersistedState(true, 'Ghost')).toBeNull()
+  })
+
+  it('round-trips the persisted state', () => {
+    persistState(true, 'Counter', { v: 99 }, 'lobby', 'u-1')
+    const got = getPersistedState(true, 'Counter')
+    expect(got).toBeTruthy()
+    expect(got!.componentName).toBe('Counter')
+    expect(got!.signedState).toEqual({ v: 99 })
+    expect(got!.room).toBe('lobby')
+    expect(got!.userId).toBe('u-1')
+  })
+
+  it('returns null and removes the key when state is older than 24h', () => {
+    const oldTs = Date.now() - (25 * 60 * 60 * 1000)
+    fake._setRaw('fluxstack_component_Stale', JSON.stringify({
+      componentName: 'Stale', signedState: {}, lastUpdate: oldTs,
+    }))
+    expect(getPersistedState(true, 'Stale')).toBeNull()
+    expect(fake.getItem('fluxstack_component_Stale')).toBeNull()
+  })
+
+  it('keeps state that is just under the 24h TTL', () => {
+    const recentTs = Date.now() - (23 * 60 * 60 * 1000)
+    fake._setRaw('fluxstack_component_Fresh', JSON.stringify({
+      componentName: 'Fresh', signedState: { ok: true }, lastUpdate: recentTs,
+    }))
+    const got = getPersistedState(true, 'Fresh')
+    expect(got).toBeTruthy()
+    expect(got!.signedState.ok).toBe(true)
+  })
+
+  it('returns null when the stored value is corrupt JSON', () => {
+    fake._setRaw('fluxstack_component_Bad', '{not json')
+    expect(getPersistedState(true, 'Bad')).toBeNull()
+  })
+})
+
+describe('clearPersistedState', () => {
+  it('removes the entry when enabled', () => {
+    persistState(true, 'X', { a: 1 })
+    clearPersistedState(true, 'X')
+    expect(fake.getItem('fluxstack_component_X')).toBeNull()
+  })
+
+  it('is a no-op when enabled is false', () => {
+    persistState(true, 'X', { a: 1 })
+    clearPersistedState(false, 'X')
+    expect(fake.getItem('fluxstack_component_X')).not.toBeNull()
+  })
+
+  it('does not throw when the key does not exist', () => {
+    expect(() => clearPersistedState(true, 'Ghost')).not.toThrow()
+  })
+})

--- a/packages/client/src/__tests__/state-validator.test.ts
+++ b/packages/client/src/__tests__/state-validator.test.ts
@@ -1,0 +1,196 @@
+// StateValidator — checksum, conflict detection, merge strategies.
+// 100+ untested LoC of client conflict-resolution logic.
+
+import { describe, it, expect } from 'vitest'
+import { StateValidator, type HybridState, type StateConflict } from '../state-validator'
+
+describe('StateValidator.generateChecksum', () => {
+  it('produces a stable hex string', () => {
+    const c = StateValidator.generateChecksum({ a: 1, b: 2 })
+    expect(typeof c).toBe('string')
+    expect(/^[0-9a-f]+$/.test(c)).toBe(true)
+  })
+
+  it('is deterministic across calls with the same input', () => {
+    const a = StateValidator.generateChecksum({ x: 'hello', n: 1 })
+    const b = StateValidator.generateChecksum({ x: 'hello', n: 1 })
+    expect(a).toBe(b)
+  })
+
+  it('is order-independent for top-level keys', () => {
+    // The implementation sorts top-level keys before stringifying.
+    const a = StateValidator.generateChecksum({ a: 1, b: 2, c: 3 })
+    const b = StateValidator.generateChecksum({ c: 3, b: 2, a: 1 })
+    expect(a).toBe(b)
+  })
+
+  it('changes when a value changes', () => {
+    const a = StateValidator.generateChecksum({ x: 1 })
+    const b = StateValidator.generateChecksum({ x: 2 })
+    expect(a).not.toBe(b)
+  })
+
+  it('changes when a new key is added', () => {
+    const a = StateValidator.generateChecksum({ x: 1 })
+    const b = StateValidator.generateChecksum({ x: 1, y: 2 })
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('StateValidator.createValidation', () => {
+  it('returns a validation object with all required fields', () => {
+    const v = StateValidator.createValidation({ x: 1 }, 'server')
+    expect(v.checksum).toBeDefined()
+    expect(typeof v.version).toBe('number')
+    expect(typeof v.timestamp).toBe('number')
+    expect(v.source).toBe('server')
+  })
+
+  it('defaults source to client', () => {
+    const v = StateValidator.createValidation({ x: 1 })
+    expect(v.source).toBe('client')
+  })
+})
+
+describe('StateValidator.detectConflicts', () => {
+  it('returns no conflicts when client and server states are identical', () => {
+    const conflicts = StateValidator.detectConflicts({ x: 1, y: 2 }, { x: 1, y: 2 })
+    expect(conflicts).toEqual([])
+  })
+
+  it('detects a value mismatch', () => {
+    const conflicts = StateValidator.detectConflicts({ x: 1 }, { x: 2 })
+    expect(conflicts).toHaveLength(1)
+    expect(conflicts[0]!.property).toBe('x')
+    expect(conflicts[0]!.clientValue).toBe(1)
+    expect(conflicts[0]!.serverValue).toBe(2)
+    expect(conflicts[0]!.resolved).toBe(false)
+  })
+
+  it('detects keys present only on the server', () => {
+    const conflicts = StateValidator.detectConflicts({ x: 1 }, { x: 1, extra: 'y' })
+    expect(conflicts).toHaveLength(1)
+    expect(conflicts[0]!.property).toBe('extra')
+    expect(conflicts[0]!.clientValue).toBeUndefined()
+    expect(conflicts[0]!.serverValue).toBe('y')
+  })
+
+  it('detects keys present only on the client', () => {
+    const conflicts = StateValidator.detectConflicts({ x: 1, ghost: 99 }, { x: 1 })
+    expect(conflicts).toHaveLength(1)
+    expect(conflicts[0]!.property).toBe('ghost')
+  })
+
+  it('excludes lastUpdated and version by default', () => {
+    const conflicts = StateValidator.detectConflicts(
+      { x: 1, lastUpdated: 100, version: 1 },
+      { x: 1, lastUpdated: 200, version: 2 },
+    )
+    expect(conflicts).toEqual([])
+  })
+
+  it('respects custom excludeFields', () => {
+    const conflicts = StateValidator.detectConflicts(
+      { x: 1, y: 'a' },
+      { x: 2, y: 'b' },
+      ['y'],
+    )
+    expect(conflicts.map(c => c.property)).toEqual(['x'])
+  })
+
+  it('detects nested object differences (via JSON.stringify comparison)', () => {
+    const conflicts = StateValidator.detectConflicts(
+      { nested: { a: 1 } },
+      { nested: { a: 2 } },
+    )
+    expect(conflicts).toHaveLength(1)
+    expect(conflicts[0]!.property).toBe('nested')
+  })
+
+  it('handles null/undefined inputs gracefully', () => {
+    expect(() => StateValidator.detectConflicts(null as any, { x: 1 })).not.toThrow()
+    expect(() => StateValidator.detectConflicts({ x: 1 }, null as any)).not.toThrow()
+  })
+})
+
+describe('StateValidator.mergeStates', () => {
+  const conflicts: StateConflict[] = [
+    { property: 'count', clientValue: 5, serverValue: 10, timestamp: 0, resolved: false },
+    { property: 'name', clientValue: 'alice', serverValue: 'bob', timestamp: 0, resolved: false },
+  ]
+
+  it('strategy=client keeps the client values', () => {
+    const merged = StateValidator.mergeStates({ count: 5, name: 'alice' }, { count: 10, name: 'bob' }, conflicts, 'client')
+    expect(merged).toEqual({ count: 5, name: 'alice' })
+  })
+
+  it('strategy=server overwrites client with server values', () => {
+    const merged = StateValidator.mergeStates({ count: 5, name: 'alice' }, { count: 10, name: 'bob' }, conflicts, 'server')
+    expect(merged).toEqual({ count: 10, name: 'bob' })
+  })
+
+  it('strategy=smart picks max for numeric, server for non-numeric', () => {
+    const merged = StateValidator.mergeStates({ count: 5, name: 'alice' }, { count: 10, name: 'bob' }, conflicts, 'smart')
+    expect(merged.count).toBe(10) // max(5,10)
+    expect(merged.name).toBe('bob') // non-numeric → server wins
+  })
+
+  it('strategy=smart picks max even when client is higher', () => {
+    const c = [{ property: 'count', clientValue: 99, serverValue: 50, timestamp: 0, resolved: false }]
+    const merged = StateValidator.mergeStates({ count: 99 }, { count: 50 }, c, 'smart')
+    expect(merged.count).toBe(99)
+  })
+
+  it('strategy=smart uses server value for lastUpdated specifically', () => {
+    const c = [{ property: 'lastUpdated', clientValue: 1000, serverValue: 2000, timestamp: 0, resolved: false }]
+    const merged: any = StateValidator.mergeStates({ lastUpdated: 1000 }, { lastUpdated: 2000 }, c, 'smart')
+    expect(merged.lastUpdated).toBe(2000)
+  })
+
+  it('returns a new object (does not mutate inputs)', () => {
+    const client = { count: 5 }
+    const merged = StateValidator.mergeStates(client, { count: 10 }, [{ property: 'count', clientValue: 5, serverValue: 10, timestamp: 0, resolved: false }], 'server')
+    expect(merged).not.toBe(client)
+    expect(client.count).toBe(5)
+  })
+})
+
+describe('StateValidator.validateState', () => {
+  it('returns true when the checksum matches the current state', () => {
+    const data = { x: 1, y: 2 }
+    const state: HybridState<typeof data> = {
+      data,
+      validation: StateValidator.createValidation(data),
+      status: 'synced',
+    }
+    expect(StateValidator.validateState(state)).toBe(true)
+  })
+
+  it('returns false when the data has been tampered with after checksum', () => {
+    const data = { x: 1, y: 2 }
+    const state: HybridState<typeof data> = {
+      data,
+      validation: StateValidator.createValidation(data),
+      status: 'synced',
+    }
+    // Mutate AFTER checksum captured
+    state.data.x = 99
+    expect(StateValidator.validateState(state)).toBe(false)
+  })
+})
+
+describe('StateValidator.updateValidation', () => {
+  it('returns a new HybridState with a fresh validation and synced status', () => {
+    const data = { x: 1 }
+    const orig: HybridState<typeof data> = {
+      data,
+      validation: { checksum: 'stale', version: 0, timestamp: 0, source: 'mount' },
+      status: 'pending',
+    }
+    const updated = StateValidator.updateValidation(orig, 'server')
+    expect(updated.status).toBe('synced')
+    expect(updated.validation.source).toBe('server')
+    expect(updated.validation.checksum).not.toBe('stale')
+    expect(updated.data).toBe(data) // same data reference
+  })
+})

--- a/packages/client/src/state-validator.ts
+++ b/packages/client/src/state-validator.ts
@@ -51,8 +51,10 @@ export class StateValidator {
     excludeFields: string[] = ['lastUpdated', 'version'],
   ): StateConflict[] {
     const conflicts: StateConflict[] = []
-    const clientKeys = Object.keys(clientState as any)
-    const serverKeys = Object.keys(serverState as any)
+    // Guard against null/undefined — Object.keys throws on those, and the
+    // hybrid-state path can hand us either side as null (mount-before-sync).
+    const clientKeys = (clientState && typeof clientState === 'object') ? Object.keys(clientState as any) : []
+    const serverKeys = (serverState && typeof serverState === 'object') ? Object.keys(serverState as any) : []
     const allKeys = Array.from(new Set([...clientKeys, ...serverKeys]))
 
     for (const key of allKeys) {

--- a/packages/core/src/__tests__/rooms/RoomRegistry.test.ts
+++ b/packages/core/src/__tests__/rooms/RoomRegistry.test.ts
@@ -1,0 +1,143 @@
+// RoomRegistry — registration, lookup, compound-id resolution, type guard.
+// Zero coverage previously despite being the single source of truth for
+// LiveRoom dispatch.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { RoomRegistry } from '../../rooms/RoomRegistry'
+import { LiveRoom } from '../../rooms/LiveRoom'
+
+class ChatRoom extends LiveRoom<{ messages: string[] }> {
+  static roomName = 'chat'
+  static defaultState = { messages: [] as string[] }
+}
+
+class GameRoom extends LiveRoom<{ score: number }> {
+  static roomName = 'game'
+  static defaultState = { score: 0 }
+}
+
+class HyphenatedRoom extends LiveRoom<{ x: number }> {
+  static roomName = 'my-room'
+  static defaultState = { x: 0 }
+}
+
+let reg: RoomRegistry
+beforeEach(() => { reg = new RoomRegistry() })
+
+describe('RoomRegistry.register', () => {
+  it('registers a valid LiveRoom subclass', () => {
+    reg.register(ChatRoom as any)
+    expect(reg.has('chat')).toBe(true)
+  })
+
+  it('throws when roomName is missing', () => {
+    class NoName extends LiveRoom<{ x: number }> {
+      static defaultState = { x: 0 }
+    }
+    expect(() => reg.register(NoName as any)).toThrow(/must define static roomName/)
+  })
+
+  it('throws on duplicate registration', () => {
+    reg.register(ChatRoom as any)
+    expect(() => reg.register(ChatRoom as any)).toThrow(/already registered/)
+  })
+
+  it('allows distinct roomNames to coexist', () => {
+    reg.register(ChatRoom as any)
+    reg.register(GameRoom as any)
+    expect(reg.getRegisteredNames().sort()).toEqual(['chat', 'game'])
+  })
+})
+
+describe('RoomRegistry.get / has', () => {
+  it('returns the class for a registered name', () => {
+    reg.register(ChatRoom as any)
+    expect(reg.get('chat')).toBe(ChatRoom)
+  })
+
+  it('returns undefined for an unknown name', () => {
+    expect(reg.get('ghost')).toBeUndefined()
+    expect(reg.has('ghost')).toBe(false)
+  })
+})
+
+describe('RoomRegistry.resolveFromId', () => {
+  beforeEach(() => {
+    reg.register(ChatRoom as any)
+    reg.register(GameRoom as any)
+    reg.register(HyphenatedRoom as any)
+  })
+
+  it('resolves chat:lobby → ChatRoom', () => {
+    expect(reg.resolveFromId('chat:lobby')).toBe(ChatRoom)
+  })
+
+  it('resolves my-room:any → HyphenatedRoom (hyphens in prefix allowed)', () => {
+    expect(reg.resolveFromId('my-room:test')).toBe(HyphenatedRoom)
+  })
+
+  it('returns undefined for ids without a colon', () => {
+    expect(reg.resolveFromId('chat')).toBeUndefined()
+    expect(reg.resolveFromId('justaroom')).toBeUndefined()
+  })
+
+  it('returns undefined for unknown prefix', () => {
+    expect(reg.resolveFromId('unknown:x')).toBeUndefined()
+  })
+
+  it('uses only the prefix before the FIRST colon (chat:a:b → ChatRoom)', () => {
+    expect(reg.resolveFromId('chat:a:b:c')).toBe(ChatRoom)
+  })
+
+  it('empty prefix (":lobby") resolves to undefined', () => {
+    expect(reg.resolveFromId(':lobby')).toBeUndefined()
+  })
+})
+
+describe('RoomRegistry.getRegisteredNames', () => {
+  it('returns an empty array when nothing is registered', () => {
+    expect(reg.getRegisteredNames()).toEqual([])
+  })
+
+  it('returns all registered names', () => {
+    reg.register(ChatRoom as any)
+    reg.register(GameRoom as any)
+    expect(reg.getRegisteredNames().sort()).toEqual(['chat', 'game'])
+  })
+})
+
+describe('RoomRegistry.isLiveRoomClass', () => {
+  it('recognizes a LiveRoom subclass', () => {
+    expect(RoomRegistry.isLiveRoomClass(ChatRoom)).toBe(true)
+  })
+
+  it('rejects a plain function', () => {
+    expect(RoomRegistry.isLiveRoomClass(() => {})).toBe(false)
+  })
+
+  it('rejects null / undefined / primitives', () => {
+    expect(RoomRegistry.isLiveRoomClass(null)).toBe(false)
+    expect(RoomRegistry.isLiveRoomClass(undefined)).toBe(false)
+    expect(RoomRegistry.isLiveRoomClass('chat')).toBe(false)
+    expect(RoomRegistry.isLiveRoomClass(42)).toBe(false)
+  })
+
+  it('rejects a class without roomName', () => {
+    class Bare {}
+    expect(RoomRegistry.isLiveRoomClass(Bare)).toBe(false)
+  })
+
+  it('rejects a class with roomName but not extending LiveRoom', () => {
+    class Fake {
+      static roomName = 'fake'
+    }
+    expect(RoomRegistry.isLiveRoomClass(Fake)).toBe(false)
+  })
+
+  it('recognizes a subclass of a LiveRoom subclass (deep prototype chain)', () => {
+    class GameTournamentRoom extends GameRoom {
+      static roomName = 'tournament'
+    }
+    expect(RoomRegistry.isLiveRoomClass(GameTournamentRoom)).toBe(true)
+  })
+})

--- a/packages/core/src/__tests__/upload/FileUploadManager.test.ts
+++ b/packages/core/src/__tests__/upload/FileUploadManager.test.ts
@@ -1,0 +1,412 @@
+// FileUploadManager — security & correctness tests.
+// This manager is the gatekeeper between attacker-supplied bytes and the
+// host filesystem. It has many defenses (allowedTypes, blockedExtensions,
+// magic-byte validation, quota, double-extension detection, filename
+// sanitization) and zero tests prior to this file.
+//
+// Strategy: use a custom assembleFile so we never touch disk, then drive
+// real attack scenarios through startUpload / receiveChunk / completeUpload.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { FileUploadManager } from '../../upload/FileUploadManager'
+import type { ActiveUpload } from '../../protocol/messages'
+
+vi.mock('../../debug/LiveLogger', () => ({
+  liveLog: vi.fn(),
+  liveWarn: vi.fn(),
+}))
+
+// ── Magic bytes for fixtures ───────────────────────────────────────────
+const PNG_HEADER = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+const JPEG_HEADER = [0xFF, 0xD8, 0xFF]
+const PDF_HEADER = [0x25, 0x50, 0x44, 0x46] // "%PDF"
+
+function makeChunk(prefix: number[], padBytes = 100): string {
+  const buf = Buffer.alloc(prefix.length + padBytes)
+  for (let i = 0; i < prefix.length; i++) buf[i] = prefix[i]!
+  return buf.toString('base64')
+}
+
+interface MgrSetup {
+  mgr: FileUploadManager
+  assembled: ActiveUpload[]
+}
+
+function makeMgr(config?: ConstructorParameters<typeof FileUploadManager>[0]): MgrSetup {
+  const assembled: ActiveUpload[] = []
+  const mgr = new FileUploadManager({
+    ...config,
+    assembleFile: async (upload) => {
+      assembled.push(upload)
+      return `/fake/${upload.uploadId}`
+    },
+  })
+  return { mgr, assembled }
+}
+
+let mgr: FileUploadManager
+beforeEach(() => { /* fresh per-test */ })
+afterEach(() => { mgr?.shutdown() })
+
+// ─────────────────────────────────────────────────────────────────────────
+// Size + quota
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('FileUploadManager — size & quota', () => {
+  it('rejects upload above maxUploadSize', async () => {
+    const setup = makeMgr({ maxUploadSize: 1024 })
+    mgr = setup.mgr
+    const r = await mgr.startUpload({
+      uploadId: 'u1', componentId: 'c1', filename: 'x.png', fileType: 'image/png',
+      fileSize: 2048, chunkSize: 1024,
+    } as any)
+    expect(r.success).toBe(false)
+    expect(r.error).toMatch(/too large/i)
+  })
+
+  it('rejects upload above per-user quota', async () => {
+    const setup = makeMgr({ maxBytesPerUser: 1000 })
+    mgr = setup.mgr
+    const r = await mgr.startUpload(
+      { uploadId: 'u1', componentId: 'c1', filename: 'x.png', fileType: 'image/png', fileSize: 2000 } as any,
+      'alice',
+    )
+    expect(r.success).toBe(false)
+    expect(r.error).toMatch(/quota/i)
+  })
+
+  it('accumulates quota across multiple uploads from same user', async () => {
+    const setup = makeMgr({ maxBytesPerUser: 1000 })
+    mgr = setup.mgr
+    await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'a.png', fileType: 'image/png', fileSize: 600 } as any, 'alice')
+    const second = await mgr.startUpload({ uploadId: 'u2', componentId: 'c1', filename: 'b.png', fileType: 'image/png', fileSize: 500 } as any, 'alice')
+    expect(second.success).toBe(false)
+    expect(second.error).toMatch(/quota/i)
+  })
+
+  it('isolates quota between different users', async () => {
+    const setup = makeMgr({ maxBytesPerUser: 1000 })
+    mgr = setup.mgr
+    await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'a.png', fileType: 'image/png', fileSize: 900 } as any, 'alice')
+    const bob = await mgr.startUpload({ uploadId: 'u2', componentId: 'c2', filename: 'b.png', fileType: 'image/png', fileSize: 900 } as any, 'bob')
+    expect(bob.success).toBe(true)
+  })
+
+  it('getUserUploadUsage reports current usage and remaining', async () => {
+    const setup = makeMgr({ maxBytesPerUser: 1000 })
+    mgr = setup.mgr
+    await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'a.png', fileType: 'image/png', fileSize: 400 } as any, 'alice')
+    expect(mgr.getUserUploadUsage('alice')).toEqual({ used: 400, limit: 1000, remaining: 600 })
+  })
+
+  it('anonymous uploads (no userId) skip quota check', async () => {
+    const setup = makeMgr({ maxBytesPerUser: 10 })
+    mgr = setup.mgr
+    const r = await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'a.png', fileType: 'image/png', fileSize: 999999 } as any)
+    expect(r.success).toBe(true)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// MIME type allowlist
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('FileUploadManager — type allowlist', () => {
+  it('rejects MIME types not in allowedTypes', async () => {
+    const setup = makeMgr({ allowedTypes: ['image/png'] })
+    mgr = setup.mgr
+    const r = await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'x.exe', fileType: 'application/x-msdownload', fileSize: 100 } as any)
+    expect(r.success).toBe(false)
+    expect(r.error).toMatch(/not allowed/i)
+  })
+
+  it('empty allowedTypes acts as wildcard (default off-the-shelf is restrictive)', async () => {
+    const setup = makeMgr({ allowedTypes: [] })
+    mgr = setup.mgr
+    const r = await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'x.png', fileType: 'image/png', fileSize: 100 } as any)
+    expect(r.success).toBe(true)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// Blocked extensions + double-extension
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('FileUploadManager — extension blocking', () => {
+  it('rejects executable extension (.exe)', async () => {
+    const setup = makeMgr({ allowedTypes: [] })
+    mgr = setup.mgr
+    const r = await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'malware.exe', fileType: 'application/octet-stream', fileSize: 100 } as any)
+    expect(r.success).toBe(false)
+    expect(r.error).toMatch(/extension not allowed/i)
+  })
+
+  it('detects double-extension (malware.exe.png)', async () => {
+    const setup = makeMgr({ allowedTypes: [] })
+    mgr = setup.mgr
+    const r = await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'innocent.exe.png', fileType: 'image/png', fileSize: 100 } as any)
+    expect(r.success).toBe(false)
+    expect(r.error).toMatch(/double extension/i)
+  })
+
+  it('detects double-extension with bash (file.sh.txt)', async () => {
+    const setup = makeMgr({ allowedTypes: [] })
+    mgr = setup.mgr
+    const r = await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'innocent.sh.txt', fileType: 'text/plain', fileSize: 100 } as any)
+    expect(r.success).toBe(false)
+    expect(r.error).toMatch(/double extension/i)
+  })
+
+  it('accepts single dot extension files normally', async () => {
+    const setup = makeMgr({ allowedTypes: [] })
+    mgr = setup.mgr
+    const r = await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'photo.png', fileType: 'image/png', fileSize: 100 } as any)
+    expect(r.success).toBe(true)
+  })
+
+  it('rejects filename longer than 255 chars', async () => {
+    const setup = makeMgr({ allowedTypes: [] })
+    mgr = setup.mgr
+    const longName = 'a'.repeat(260) + '.png'
+    const r = await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: longName, fileType: 'image/png', fileSize: 100 } as any)
+    expect(r.success).toBe(false)
+    expect(r.error).toMatch(/too long/i)
+  })
+
+  it('basename strips path traversal (../../etc/passwd)', async () => {
+    const setup = makeMgr({ allowedTypes: [] })
+    mgr = setup.mgr
+    // Should succeed because basename strips the directory traversal,
+    // leaving just "passwd" (no extension, no block).
+    const r = await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: '../../etc/passwd', fileType: 'text/plain', fileSize: 100 } as any)
+    expect(r.success).toBe(true)
+    // Confirm the active upload kept the (raw) filename — the basename
+    // strip only happens at validation. The actual disk path is generated
+    // by defaultAssembleFile using crypto.randomUUID(), so traversal can't
+    // escape the uploads dir even if validation passed.
+    expect(mgr.getUploadStatus('u1')?.filename).toBe('../../etc/passwd')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// uploadId collisions
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('FileUploadManager — uploadId collisions', () => {
+  it('rejects starting an upload with an in-progress uploadId', async () => {
+    const setup = makeMgr({ allowedTypes: [] })
+    mgr = setup.mgr
+    await mgr.startUpload({ uploadId: 'dup', componentId: 'c1', filename: 'a.png', fileType: 'image/png', fileSize: 100 } as any)
+    const r = await mgr.startUpload({ uploadId: 'dup', componentId: 'c1', filename: 'b.png', fileType: 'image/png', fileSize: 100 } as any)
+    expect(r.success).toBe(false)
+    expect(r.error).toMatch(/already in progress/i)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// Chunk handling — bounds and integrity
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('FileUploadManager — chunk handling', () => {
+  it('rejects negative chunk index', async () => {
+    const setup = makeMgr({ allowedTypes: [] })
+    mgr = setup.mgr
+    await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'a.png', fileType: 'image/png', fileSize: 100, chunkSize: 50 } as any)
+    await expect(
+      mgr.receiveChunk({ uploadId: 'u1', chunkIndex: -1, totalChunks: 2, data: '' } as any, null),
+    ).rejects.toThrow(/invalid chunk index/i)
+  })
+
+  it('rejects chunk index >= totalChunks', async () => {
+    const setup = makeMgr({ allowedTypes: [] })
+    mgr = setup.mgr
+    await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'a.png', fileType: 'image/png', fileSize: 100, chunkSize: 50 } as any)
+    await expect(
+      mgr.receiveChunk({ uploadId: 'u1', chunkIndex: 99, totalChunks: 2, data: '' } as any, null),
+    ).rejects.toThrow(/invalid chunk index/i)
+  })
+
+  it('rejects chunk for unknown uploadId', async () => {
+    const setup = makeMgr({ allowedTypes: [] })
+    mgr = setup.mgr
+    await expect(
+      mgr.receiveChunk({ uploadId: 'ghost', chunkIndex: 0, totalChunks: 1, data: '' } as any, null),
+    ).rejects.toThrow(/not found/i)
+  })
+
+  it('duplicate chunk index is idempotent (does not double-count bytes)', async () => {
+    const setup = makeMgr({ allowedTypes: [] })
+    mgr = setup.mgr
+    await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'a.png', fileType: 'image/png', fileSize: 200, chunkSize: 100 } as any)
+    const chunk0 = Buffer.alloc(100).toString('base64')
+    await mgr.receiveChunk({ uploadId: 'u1', chunkIndex: 0, totalChunks: 2, data: chunk0 } as any, null)
+    await mgr.receiveChunk({ uploadId: 'u1', chunkIndex: 0, totalChunks: 2, data: chunk0 } as any, null)
+    expect(mgr.getUploadStatus('u1')?.bytesReceived).toBe(100)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// Magic bytes — content-spoofing defense
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('FileUploadManager — magic byte validation', () => {
+  it('rejects PNG content claiming to be JPEG', async () => {
+    const setup = makeMgr({ allowedTypes: ['image/jpeg'] })
+    mgr = setup.mgr
+    const fileSize = 108
+    await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'x.jpg', fileType: 'image/jpeg', fileSize, chunkSize: fileSize } as any)
+    // Send a chunk with PNG magic bytes despite the declared type.
+    await mgr.receiveChunk({ uploadId: 'u1', chunkIndex: 0, totalChunks: 1, data: makeChunk(PNG_HEADER) } as any, null)
+    const r = await mgr.completeUpload({ uploadId: 'u1' } as any)
+    expect(r.success).toBe(false)
+    expect(r.error).toMatch(/disguised|does not match/i)
+  })
+
+  it('accepts JPEG content with matching JPEG header', async () => {
+    const setup = makeMgr({ allowedTypes: ['image/jpeg'] })
+    mgr = setup.mgr
+    const fileSize = 103
+    await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'x.jpg', fileType: 'image/jpeg', fileSize, chunkSize: fileSize } as any)
+    await mgr.receiveChunk({ uploadId: 'u1', chunkIndex: 0, totalChunks: 1, data: makeChunk(JPEG_HEADER) } as any, null)
+    const r = await mgr.completeUpload({ uploadId: 'u1' } as any)
+    expect(r.success).toBe(true)
+  })
+
+  it('accepts PDF content with matching %PDF header', async () => {
+    const setup = makeMgr({ allowedTypes: ['application/pdf'] })
+    mgr = setup.mgr
+    const fileSize = 104
+    await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'doc.pdf', fileType: 'application/pdf', fileSize, chunkSize: fileSize } as any)
+    await mgr.receiveChunk({ uploadId: 'u1', chunkIndex: 0, totalChunks: 1, data: makeChunk(PDF_HEADER) } as any, null)
+    const r = await mgr.completeUpload({ uploadId: 'u1' } as any)
+    expect(r.success).toBe(true)
+  })
+
+  it('rejects PDF disguised as ZIP', async () => {
+    const setup = makeMgr({ allowedTypes: ['application/zip'] })
+    mgr = setup.mgr
+    const fileSize = 104
+    await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'fake.zip', fileType: 'application/zip', fileSize, chunkSize: fileSize } as any)
+    await mgr.receiveChunk({ uploadId: 'u1', chunkIndex: 0, totalChunks: 1, data: makeChunk(PDF_HEADER) } as any, null)
+    const r = await mgr.completeUpload({ uploadId: 'u1' } as any)
+    expect(r.success).toBe(false)
+  })
+
+  it('skips magic-byte check for types without a signature (e.g. text/plain)', async () => {
+    const setup = makeMgr({ allowedTypes: ['text/plain'] })
+    mgr = setup.mgr
+    const data = Buffer.from('hello world', 'utf-8').toString('base64')
+    const fileSize = 11
+    await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'note.txt', fileType: 'text/plain', fileSize, chunkSize: fileSize } as any)
+    await mgr.receiveChunk({ uploadId: 'u1', chunkIndex: 0, totalChunks: 1, data } as any, null)
+    const r = await mgr.completeUpload({ uploadId: 'u1' } as any)
+    expect(r.success).toBe(true)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// completeUpload — integrity
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('FileUploadManager — completeUpload integrity', () => {
+  it('rejects complete when bytesReceived !== fileSize', async () => {
+    const setup = makeMgr({ allowedTypes: ['image/png'] })
+    mgr = setup.mgr
+    const declaredSize = 1000
+    await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'a.png', fileType: 'image/png', fileSize: declaredSize, chunkSize: declaredSize } as any)
+    // Send only 100 bytes
+    await mgr.receiveChunk({ uploadId: 'u1', chunkIndex: 0, totalChunks: 1, data: makeChunk(PNG_HEADER, 92) } as any, null)
+    const r = await mgr.completeUpload({ uploadId: 'u1' } as any)
+    expect(r.success).toBe(false)
+    expect(r.error).toMatch(/incomplete/i)
+  })
+
+  it('rejects complete for unknown uploadId', async () => {
+    const setup = makeMgr({ allowedTypes: [] })
+    mgr = setup.mgr
+    const r = await mgr.completeUpload({ uploadId: 'ghost' } as any)
+    expect(r.success).toBe(false)
+    expect(r.error).toMatch(/not found/i)
+  })
+
+  it('removes upload from active list after successful complete', async () => {
+    const setup = makeMgr({ allowedTypes: ['image/png'] })
+    mgr = setup.mgr
+    const fileSize = 108
+    await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'a.png', fileType: 'image/png', fileSize, chunkSize: fileSize } as any)
+    await mgr.receiveChunk({ uploadId: 'u1', chunkIndex: 0, totalChunks: 1, data: makeChunk(PNG_HEADER) } as any, null)
+    expect(mgr.getUploadStatus('u1')).toBeTruthy()
+    await mgr.completeUpload({ uploadId: 'u1' } as any)
+    expect(mgr.getUploadStatus('u1')).toBeNull()
+  })
+
+  it('invokes custom assembleFile and returns its URL', async () => {
+    const setup = makeMgr({ allowedTypes: ['image/png'] })
+    mgr = setup.mgr
+    const fileSize = 108
+    await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'a.png', fileType: 'image/png', fileSize, chunkSize: fileSize } as any)
+    await mgr.receiveChunk({ uploadId: 'u1', chunkIndex: 0, totalChunks: 1, data: makeChunk(PNG_HEADER) } as any, null)
+    const r = await mgr.completeUpload({ uploadId: 'u1' } as any)
+    expect(r.success).toBe(true)
+    expect(r.fileUrl).toBe('/fake/u1')
+    expect(setup.assembled).toHaveLength(1)
+    expect(setup.assembled[0]!.filename).toBe('a.png')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// Cancellation
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('FileUploadManager — cancellation', () => {
+  it('cancelUpload removes the upload', async () => {
+    const setup = makeMgr({ allowedTypes: [] })
+    mgr = setup.mgr
+    await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'a.png', fileType: 'image/png', fileSize: 100 } as any)
+    expect(mgr.cancelUpload('u1')).toBe(true)
+    expect(mgr.getUploadStatus('u1')).toBeNull()
+  })
+
+  it('cancelUpload returns false for unknown id', () => {
+    const setup = makeMgr({ allowedTypes: [] })
+    mgr = setup.mgr
+    expect(mgr.cancelUpload('ghost')).toBe(false)
+  })
+
+  it('cancelComponentUploads removes all uploads for the component', async () => {
+    const setup = makeMgr({ allowedTypes: [] })
+    mgr = setup.mgr
+    await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'a.png', fileType: 'image/png', fileSize: 100 } as any)
+    await mgr.startUpload({ uploadId: 'u2', componentId: 'c1', filename: 'b.png', fileType: 'image/png', fileSize: 100 } as any)
+    await mgr.startUpload({ uploadId: 'u3', componentId: 'c2', filename: 'c.png', fileType: 'image/png', fileSize: 100 } as any)
+    expect(mgr.cancelComponentUploads('c1')).toBe(2)
+    expect(mgr.getUploadStatus('u1')).toBeNull()
+    expect(mgr.getUploadStatus('u2')).toBeNull()
+    expect(mgr.getUploadStatus('u3')).toBeTruthy()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// Known limitation: quota is not refunded on cancel
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('FileUploadManager — known limitations (regression guards)', () => {
+  it('quota is NOT refunded when an upload is cancelled (documents current behavior)', async () => {
+    const setup = makeMgr({ maxBytesPerUser: 1000 })
+    mgr = setup.mgr
+    await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'a.png', fileType: 'image/png', fileSize: 600 } as any, 'alice')
+    mgr.cancelUpload('u1')
+    // Alice still shows 600 used because cancelUpload doesn't refund.
+    // Documenting this so a future "fix" knows there's a known gap.
+    expect(mgr.getUserUploadUsage('alice').used).toBe(600)
+  })
+
+  it('quota is NOT refunded on failed/incomplete upload (documents current behavior)', async () => {
+    const setup = makeMgr({ maxBytesPerUser: 1000, allowedTypes: ['image/png'] })
+    mgr = setup.mgr
+    await mgr.startUpload({ uploadId: 'u1', componentId: 'c1', filename: 'a.png', fileType: 'image/png', fileSize: 500, chunkSize: 500 } as any, 'alice')
+    // Complete fails (no chunk uploaded) — quota still counts.
+    await mgr.completeUpload({ uploadId: 'u1' } as any)
+    expect(mgr.getUserUploadUsage('alice').used).toBe(500)
+  })
+})


### PR DESCRIPTION
## Summary

Adds **91 tests** across 4 modules that had **zero** coverage despite being on critical paths. Found and fixed one real bug along the way.

| Module | Tests | Why it matters |
|---|---|---|
| \`FileUploadManager\` | 33 | Server-side gatekeeper between attacker bytes and the host filesystem. Magic-byte spoof prevention, quota, path-traversal, double-extension, all uncovered. |
| \`StateValidator\` (client) | 24 | Checksum + conflict-detection + merge strategies. 100+ LoC of conflict logic. |
| \`persistence\` (client) | 14 | localStorage round-trip with 24h TTL — silent corruption / quota issues hard to debug in prod. |
| \`RoomRegistry\` | 20 | Single source of truth for LiveRoom dispatch (\`chat:lobby\` → ChatRoom). |

## Bug found + fixed

\`StateValidator.detectConflicts\` threw \`TypeError\` on \`null\`/\`undefined\` inputs because \`Object.keys(null)\` is illegal. The hybrid-state path can hand us either side as \`null\` during mount-before-sync. Both arguments now guarded:

\`\`\`ts
const clientKeys = (clientState && typeof clientState === 'object') ? Object.keys(clientState as any) : []
const serverKeys = (serverState && typeof serverState === 'object') ? Object.keys(serverState as any) : []
\`\`\`

## What's covered

### FileUploadManager (33)
- **Size + quota** (6): maxUploadSize, per-user quota, accumulation, isolation, usage reporting, anonymous bypass
- **Type allowlist** (2): rejection, empty = wildcard
- **Extension blocking** (6): .exe, double-extension malware.exe.png, double bash file.sh.txt, single dot ok, >255 char filename, basename strips path-traversal
- **uploadId collisions** (1): in-progress duplicate rejected
- **Chunk handling** (4): negative index, out-of-range, unknown uploadId, duplicate idempotent
- **Magic bytes** (5): PNG-as-JPEG rejected, JPEG ok, PDF ok, PDF-as-ZIP rejected, text/plain skip
- **Complete** (4): incomplete bytes, unknown id, removes from active, custom assemble URL
- **Cancellation** (3): single, by component, unknown
- **Known limitations** (2): quota not refunded on cancel or failed complete (regression guards)

### StateValidator (24)
- generateChecksum (5): hex output, determinism, order-independent, change detection
- createValidation (2): full shape, default source
- detectConflicts (8): identical states, value mismatch, server-only / client-only keys, default + custom excludes, nested objects, null/undefined guard
- mergeStates (6): client/server/smart strategies, smart numeric max, smart lastUpdated special case, immutability
- validateState (2): match + tamper detection
- updateValidation (1): new HybridState with synced status

### persistence (14)
- persistState (5): write + JSON shape, no-op when disabled, quota-exceeded resilience, optional fields omitted, overwrite
- getPersistedState (6): disabled, missing, round-trip, TTL expiry + removal, just-under-TTL keep, corrupt JSON
- clearPersistedState (3): remove, no-op when disabled, missing key

### RoomRegistry (20)
- register (4): valid, missing roomName throws, duplicate throws, distinct coexist
- get/has (2): registered + unknown
- resolveFromId (7): chat:lobby, hyphenated prefix, no-colon, unknown prefix, compound chat:a:b:c, empty prefix
- getRegisteredNames (2): empty, populated
- isLiveRoomClass static guard (6): subclass, plain function, null/undefined/primitives, no roomName, fake duck, deep prototype chain

## Test plan

- [x] All 91 new tests pass
- [x] Full suite: **1308 passing** (was 1217, +91), Redis included, 0 failures
- [x] Typecheck clean
- [x] No breaking change — only one minor behavior change is the null-guard in \`detectConflicts\` which previously crashed (now returns conflicts for whichever side is non-null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)