### PR TITLE
fix(core): RateLimiter clock-skew + negative-count refund (bug hunt)

### DIFF
--- a/packages/core/src/__tests__/bug-hunt/binary-protocol-edges.test.ts
+++ b/packages/core/src/__tests__/bug-hunt/binary-protocol-edges.test.ts
@@ -1,0 +1,158 @@
+// Bug hunt: binary chunk encode/decode edge cases.
+//
+// The wire format is [4 bytes headerLen LE][JSON header][binary data] and
+// `decodeBinaryChunk` reads `headerLen` from attacker-controlled bytes.
+// A truncated or lying header field is an obvious vector.
+
+import { describe, it, expect } from 'vitest'
+import { encodeBinaryChunk, decodeBinaryChunk } from '../../protocol/binary'
+import type { BinaryChunkHeader } from '../../protocol/messages'
+
+const sampleHeader: BinaryChunkHeader = {
+  type: 'FILE_UPLOAD_CHUNK',
+  uploadId: 'u-1',
+  componentId: 'c-1',
+  chunkIndex: 0,
+  totalChunks: 1,
+} as any
+
+describe('encodeBinaryChunk + decodeBinaryChunk — round-trip', () => {
+  it('round-trips a typical chunk losslessly', () => {
+    const data = Buffer.from([0x01, 0x02, 0x03, 0xFE, 0xFF])
+    const encoded = encodeBinaryChunk(sampleHeader, data)
+    const { header, data: out } = decodeBinaryChunk(encoded)
+    expect(header).toEqual(sampleHeader)
+    expect(Buffer.compare(out, data)).toBe(0)
+  })
+
+  it('round-trips an empty data buffer', () => {
+    const encoded = encodeBinaryChunk(sampleHeader, Buffer.alloc(0))
+    const { header, data } = decodeBinaryChunk(encoded)
+    expect(header).toEqual(sampleHeader)
+    expect(data.length).toBe(0)
+  })
+
+  it('round-trips a 1MB data buffer', () => {
+    const data = Buffer.alloc(1024 * 1024)
+    for (let i = 0; i < data.length; i++) data[i] = i & 0xff
+    const encoded = encodeBinaryChunk(sampleHeader, data)
+    const { data: out } = decodeBinaryChunk(encoded)
+    expect(out.length).toBe(data.length)
+    expect(Buffer.compare(out, data)).toBe(0)
+  })
+
+  it('accepts both ArrayBuffer and Uint8Array inputs', () => {
+    const encoded = encodeBinaryChunk(sampleHeader, Buffer.from([1, 2, 3]))
+    const ab = encoded.buffer.slice(encoded.byteOffset, encoded.byteOffset + encoded.byteLength)
+
+    const fromAb = decodeBinaryChunk(ab as ArrayBuffer)
+    const fromU8 = decodeBinaryChunk(new Uint8Array(ab as ArrayBuffer))
+    expect(fromAb.header).toEqual(fromU8.header)
+    expect(Buffer.compare(fromAb.data, fromU8.data)).toBe(0)
+  })
+
+  it('encode preserves data byte-for-byte across all byte values 0x00-0xFF', () => {
+    const data = Buffer.alloc(256)
+    for (let i = 0; i < 256; i++) data[i] = i
+    const { data: out } = decodeBinaryChunk(encodeBinaryChunk(sampleHeader, data))
+    expect(Buffer.compare(out, data)).toBe(0)
+  })
+
+  it('handles non-ASCII characters in header values (UTF-8)', () => {
+    const h = { ...sampleHeader, uploadId: 'üpløad-Ã¶-€' } as any
+    const { header } = decodeBinaryChunk(encodeBinaryChunk(h, Buffer.alloc(0)))
+    expect((header as any).uploadId).toBe('üpløad-Ã¶-€')
+  })
+})
+
+describe('decodeBinaryChunk — adversarial / malformed input', () => {
+  it('throws on a buffer too small to read headerLength (< 4 bytes)', () => {
+    expect(() => decodeBinaryChunk(Buffer.alloc(2))).toThrow()
+  })
+
+  it('throws on a buffer of exactly 4 bytes claiming headerLength = 0', () => {
+    // headerLen=0 → header slice is empty → JSON.parse('') throws.
+    const buf = Buffer.alloc(4)
+    buf.writeUInt32LE(0, 0)
+    expect(() => decodeBinaryChunk(buf)).toThrow(/JSON|Unexpected/i)
+  })
+
+  it('🔍 headerLength larger than the buffer truncates silently (no out-of-bounds throw)', () => {
+    // The implementation slices to `4 + headerLength` — Buffer.slice clamps
+    // to buffer length rather than throwing, so a malicious header claiming
+    // length 0xFFFFFFFF returns whatever bytes follow without error from
+    // slice itself. JSON.parse on the (likely garbage) result then throws.
+    const buf = Buffer.alloc(10)
+    buf.writeUInt32LE(0xFFFFFFFF, 0)
+    buf.write('{"a":1}', 4, 'utf-8')
+    expect(() => decodeBinaryChunk(buf)).toThrow()
+  })
+
+  it('🔍 headerLength = 0xFFFFFFFF (max uint32) does not allocate gigabytes', () => {
+    // We rely on Buffer.slice() being O(1) view-based (no copy), so this
+    // must complete quickly and just throw a JSON.parse error. If a future
+    // refactor switches to Buffer.copy/Buffer.from, this regression test
+    // would catch the memory blow-up.
+    const buf = Buffer.alloc(10)
+    buf.writeUInt32LE(0xFFFFFFFF, 0)
+    const start = Date.now()
+    expect(() => decodeBinaryChunk(buf)).toThrow()
+    expect(Date.now() - start).toBeLessThan(50)
+  })
+
+  it('throws on invalid JSON in the header region', () => {
+    const json = '{not valid json'
+    const headerBuf = Buffer.from(json, 'utf-8')
+    const buf = Buffer.alloc(4 + headerBuf.length + 5)
+    buf.writeUInt32LE(headerBuf.length, 0)
+    headerBuf.copy(buf, 4)
+    expect(() => decodeBinaryChunk(buf)).toThrow()
+  })
+
+  it('throws when header JSON is valid but binary tail is shorter than expected', () => {
+    // The decoder does not validate tail length against header — it just
+    // returns whatever bytes remain. That is documented behavior; downstream
+    // (FileUploadManager.receiveChunk) compares bytes against expected size.
+    // We assert the decoder itself accepts a short tail and returns it as-is.
+    const h = JSON.stringify(sampleHeader)
+    const headerBuf = Buffer.from(h, 'utf-8')
+    // Tail of 0 bytes
+    const buf = Buffer.alloc(4 + headerBuf.length)
+    buf.writeUInt32LE(headerBuf.length, 0)
+    headerBuf.copy(buf, 4)
+    const { data } = decodeBinaryChunk(buf)
+    expect(data.length).toBe(0)
+  })
+
+  it('🔍 headerLength = negative-as-signed (0x80000000) is read as a huge unsigned', () => {
+    // readUInt32LE on bytes 80 00 00 00 yields 0x80000000 (~2GB), not -2GB.
+    // That's correct (LE unsigned), but the resulting slice is gigantic.
+    // Make sure we still throw quickly rather than allocate.
+    const buf = Buffer.alloc(10)
+    buf.writeUInt32LE(0x80000000, 0)
+    const start = Date.now()
+    expect(() => decodeBinaryChunk(buf)).toThrow()
+    expect(Date.now() - start).toBeLessThan(50)
+  })
+
+  it('encode then decode preserves identical header object (no key reordering)', () => {
+    const h = { type: 'A', uploadId: 'X', extra: 'Y', n: 42 } as any
+    const { header } = decodeBinaryChunk(encodeBinaryChunk(h, Buffer.alloc(0)))
+    expect(header).toEqual(h)
+  })
+})
+
+describe('encodeBinaryChunk — output structure', () => {
+  it('first 4 bytes encode header length as little-endian uint32', () => {
+    const encoded = encodeBinaryChunk(sampleHeader, Buffer.alloc(0))
+    const expectedLen = Buffer.from(JSON.stringify(sampleHeader), 'utf-8').length
+    expect(encoded.readUInt32LE(0)).toBe(expectedLen)
+  })
+
+  it('total output length = 4 + headerLen + dataLen', () => {
+    const data = Buffer.from([1, 2, 3, 4, 5])
+    const encoded = encodeBinaryChunk(sampleHeader, data)
+    const headerLen = Buffer.from(JSON.stringify(sampleHeader), 'utf-8').length
+    expect(encoded.length).toBe(4 + headerLen + data.length)
+  })
+})

--- a/packages/core/src/__tests__/bug-hunt/connection-manager-edges.test.ts
+++ b/packages/core/src/__tests__/bug-hunt/connection-manager-edges.test.ts
@@ -1,0 +1,199 @@
+// Bug hunt: WebSocketConnectionManager — duplicate registration, pool
+// indexing consistency, cleanup completeness, maxConnections enforcement.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { WebSocketConnectionManager } from '../../connection/WebSocketConnectionManager'
+
+vi.mock('../../debug/LiveLogger', () => ({
+  liveLog: vi.fn(),
+  liveWarn: vi.fn(),
+}))
+
+function mockWS(readyState = 1) {
+  return { readyState, send: () => {}, close: () => {} } as any
+}
+
+let mgr: WebSocketConnectionManager
+beforeEach(() => {
+  mgr = new WebSocketConnectionManager({
+    maxConnections: 5,
+    healthCheckInterval: 999_999,
+    heartbeatInterval: 999_999,
+  })
+})
+afterEach(() => { mgr?.shutdown() })
+
+describe('registerConnection', () => {
+  it('rejects when maxConnections is exceeded', () => {
+    for (let i = 0; i < 5; i++) mgr.registerConnection(mockWS(), `c-${i}`)
+    expect(() => mgr.registerConnection(mockWS(), 'overflow')).toThrow(/Maximum connections exceeded/)
+  })
+
+  it('🔍 duplicate connectionId silently overwrites the previous registration', () => {
+    const wsA = mockWS()
+    const wsB = mockWS()
+    mgr.registerConnection(wsA, 'dup')
+    // The previous metrics object is replaced by a fresh one — any counters
+    // accumulated against the old registration are lost. This documents the
+    // current behavior so a future "reject duplicates" change knows what to
+    // break.
+    mgr.registerConnection(wsB, 'dup')
+    const stats = mgr.getSystemStats()
+    expect(stats.totalConnections).toBe(1) // overwrote in place
+    // The newer registration is the one held:
+    const metrics = mgr.getConnectionMetrics('dup')
+    expect(metrics).toBeTruthy()
+    expect(metrics!.messagesSent).toBe(0) // fresh counters
+  })
+
+  it('initializes metrics with all required fields', () => {
+    mgr.registerConnection(mockWS(), 'c-1')
+    const m = mgr.getConnectionMetrics('c-1')
+    expect(m).toMatchObject({
+      id: 'c-1',
+      status: 'connected',
+      messagesSent: 0,
+      messagesReceived: 0,
+      bytesTransferred: 0,
+      latency: 0,
+      errorCount: 0,
+      reconnectCount: 0,
+    })
+    expect(m!.connectedAt).toBeInstanceOf(Date)
+  })
+
+  it('emits connectionRegistered event with id and pool', () => {
+    const events: any[] = []
+    mgr.on('connectionRegistered', e => events.push(e))
+    mgr.registerConnection(mockWS(), 'c-1', 'pool-A')
+    expect(events).toEqual([{ connectionId: 'c-1', poolId: 'pool-A' }])
+  })
+})
+
+describe('addToPool / removeFromPool', () => {
+  it('adds a connection to multiple pools', () => {
+    mgr.registerConnection(mockWS(), 'c-1')
+    mgr.addToPool('c-1', 'P1')
+    mgr.addToPool('c-1', 'P2')
+    const stats = mgr.getSystemStats()
+    expect(stats.totalPools).toBe(2)
+  })
+
+  it('removeFromPool removes only from the specified pool', () => {
+    mgr.registerConnection(mockWS(), 'c-1')
+    mgr.addToPool('c-1', 'P1')
+    mgr.addToPool('c-1', 'P2')
+    mgr.removeFromPool('c-1', 'P1')
+    expect(mgr.getSystemStats().totalPools).toBe(1)
+  })
+
+  it('removeFromPool deletes the pool when it becomes empty', () => {
+    mgr.registerConnection(mockWS(), 'c-1')
+    mgr.registerConnection(mockWS(), 'c-2')
+    mgr.addToPool('c-1', 'P1')
+    mgr.addToPool('c-2', 'P1')
+    mgr.removeFromPool('c-1', 'P1')
+    expect(mgr.getSystemStats().totalPools).toBe(1) // P1 still has c-2
+    mgr.removeFromPool('c-2', 'P1')
+    expect(mgr.getSystemStats().totalPools).toBe(0) // empty pool removed
+  })
+
+  it('addToPool twice for same (conn, pool) is idempotent', () => {
+    mgr.registerConnection(mockWS(), 'c-1')
+    mgr.addToPool('c-1', 'P')
+    mgr.addToPool('c-1', 'P')
+    mgr.removeFromPool('c-1', 'P')
+    // One remove should fully clear, not leave a phantom membership.
+    expect(mgr.getSystemStats().totalPools).toBe(0)
+  })
+
+  it('removeFromPool on unknown pool is a no-op', () => {
+    mgr.registerConnection(mockWS(), 'c-1')
+    expect(() => mgr.removeFromPool('c-1', 'ghost')).not.toThrow()
+  })
+})
+
+describe('cleanupConnection', () => {
+  it('removes the connection, metrics, and queue', () => {
+    mgr.registerConnection(mockWS(), 'c-1')
+    mgr.cleanupConnection('c-1')
+    expect(mgr.getConnectionMetrics('c-1')).toBeNull()
+    expect(mgr.getSystemStats().totalConnections).toBe(0)
+  })
+
+  it('removes the connection from ALL pools it was in', () => {
+    mgr.registerConnection(mockWS(), 'c-1')
+    mgr.addToPool('c-1', 'P1')
+    mgr.addToPool('c-1', 'P2')
+    mgr.addToPool('c-1', 'P3')
+    mgr.cleanupConnection('c-1')
+    expect(mgr.getSystemStats().totalPools).toBe(0)
+  })
+
+  it('does not touch other connections sharing the same pools', () => {
+    mgr.registerConnection(mockWS(), 'c-1')
+    mgr.registerConnection(mockWS(), 'c-2')
+    mgr.addToPool('c-1', 'shared')
+    mgr.addToPool('c-2', 'shared')
+    mgr.cleanupConnection('c-1')
+    expect(mgr.getConnectionMetrics('c-2')).toBeTruthy()
+    expect(mgr.getSystemStats().totalPools).toBe(1)
+  })
+
+  it('cleanupConnection on unknown id is a no-op', () => {
+    expect(() => mgr.cleanupConnection('ghost')).not.toThrow()
+    expect(mgr.getSystemStats().totalConnections).toBe(0)
+  })
+
+  it('🔍 cleanup followed by re-register with the same id starts fresh', () => {
+    mgr.registerConnection(mockWS(), 'c-1')
+    mgr.addToPool('c-1', 'P')
+    mgr.cleanupConnection('c-1')
+    mgr.registerConnection(mockWS(), 'c-1') // fresh start
+    expect(mgr.getConnectionMetrics('c-1')!.messagesSent).toBe(0)
+    expect(mgr.getSystemStats().totalPools).toBe(0) // no leaked pool membership
+  })
+})
+
+describe('getSystemStats', () => {
+  it('reports active vs total separately based on readyState', () => {
+    mgr.registerConnection(mockWS(1), 'open')
+    mgr.registerConnection(mockWS(3), 'closed') // readyState 3 = CLOSED
+    const stats = mgr.getSystemStats()
+    expect(stats.totalConnections).toBe(2)
+    expect(stats.activeConnections).toBe(1)
+  })
+
+  it('counts queued messages across all connection queues', () => {
+    mgr.registerConnection(mockWS(), 'c-1')
+    mgr.registerConnection(mockWS(), 'c-2')
+    // Without a public API to push messages we just confirm zero queues.
+    expect(mgr.getSystemStats().totalQueuedMessages).toBe(0)
+  })
+})
+
+describe('getAllConnectionMetrics', () => {
+  it('returns a snapshot of every registered metrics object', () => {
+    mgr.registerConnection(mockWS(), 'a')
+    mgr.registerConnection(mockWS(), 'b')
+    const all = mgr.getAllConnectionMetrics()
+    expect(all.map(m => m.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it('returns an empty array when nothing is registered', () => {
+    expect(mgr.getAllConnectionMetrics()).toEqual([])
+  })
+})
+
+describe('shutdown', () => {
+  it('clears health and heartbeat timers (no leak)', () => {
+    // Just confirm it doesn't throw and getSystemStats still works after.
+    mgr.shutdown()
+    expect(() => mgr.getSystemStats()).not.toThrow()
+  })
+
+  it('shutdown is idempotent', () => {
+    mgr.shutdown()
+    expect(() => mgr.shutdown()).not.toThrow()
+  })
+})

--- a/packages/core/src/__tests__/bug-hunt/rate-limiter-edges.test.ts
+++ b/packages/core/src/__tests__/bug-hunt/rate-limiter-edges.test.ts
@@ -1,0 +1,149 @@
+// Bug hunt: ConnectionRateLimiter edge cases that the happy-path tests miss.
+//
+// Approach: pass values the implementation didn't think about (negative,
+// NaN, Infinity, zero) and clock manipulations that reveal hidden assumptions.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ConnectionRateLimiter, RateLimiterRegistry } from '../../connection/RateLimiter'
+
+beforeEach(() => { vi.useFakeTimers() })
+afterEach(() => { vi.useRealTimers() })
+
+describe('ConnectionRateLimiter — adversarial tryConsume() inputs', () => {
+  it('negative count is rejected (does not refund tokens)', () => {
+    const rl = new ConnectionRateLimiter(10, 1)
+    expect(rl.tryConsume(5)).toBe(true) // 5 tokens left
+    expect(rl.tryConsume(-3)).toBe(false) // negative is invalid
+    // Bucket remains at 5 — no refund occurred.
+    let after = 0
+    while (rl.tryConsume(1)) after++
+    expect(after).toBe(5)
+  })
+
+  it('count = 0 is always accepted (no-op consume)', () => {
+    const rl = new ConnectionRateLimiter(10, 1)
+    rl.tryConsume(10) // empty
+    expect(rl.tryConsume(0)).toBe(true)
+  })
+
+  it('count larger than maxTokens is always rejected, even on full bucket', () => {
+    const rl = new ConnectionRateLimiter(10, 1)
+    expect(rl.tryConsume(11)).toBe(false)
+    // Bucket unchanged
+    let used = 0
+    while (rl.tryConsume(1)) used++
+    expect(used).toBe(10)
+  })
+
+  it('count = NaN is rejected (NaN >= anything is false)', () => {
+    const rl = new ConnectionRateLimiter(10, 1)
+    // tokens >= NaN is false in JS, so consume returns false.
+    expect(rl.tryConsume(NaN)).toBe(false)
+    // Bucket untouched
+    let used = 0
+    while (rl.tryConsume(1)) used++
+    expect(used).toBe(10)
+  })
+
+  it('count = Infinity is rejected (10 >= Infinity is false)', () => {
+    const rl = new ConnectionRateLimiter(10, 1)
+    expect(rl.tryConsume(Infinity)).toBe(false)
+  })
+})
+
+describe('ConnectionRateLimiter — refill clock', () => {
+  it('refills proportional to elapsed time', () => {
+    const rl = new ConnectionRateLimiter(10, 10) // 10 tokens/sec
+    // Drain
+    while (rl.tryConsume(1)) {}
+    // Wait 500ms — should refill ~5 tokens
+    vi.advanceTimersByTime(500)
+    let got = 0
+    while (rl.tryConsume(1)) got++
+    expect(got).toBeGreaterThanOrEqual(4)
+    expect(got).toBeLessThanOrEqual(6)
+  })
+
+  it('refill caps at maxTokens (does not exceed bucket size)', () => {
+    const rl = new ConnectionRateLimiter(5, 100)
+    vi.advanceTimersByTime(10_000) // way more than enough to overflow
+    let got = 0
+    while (rl.tryConsume(1)) got++
+    expect(got).toBe(5)
+  })
+
+  it('backwards clock skew does NOT corrupt the bucket (regression: bug found via tests)', () => {
+    const rl = new ConnectionRateLimiter(10, 10)
+    rl.tryConsume(10) // empty bucket
+
+    // Simulate the system clock moving backwards by 1 minute. The previous
+    // implementation produced negative `elapsed`, credited negative tokens,
+    // and left the bucket permanently broken. The fix clamps elapsed to >=0.
+    const start = Date.now()
+    vi.spyOn(Date, 'now').mockReturnValue(start - 60_000)
+    expect(rl.tryConsume(0)).toBe(true) // refill no-op, bucket still empty but not negative
+    expect(rl.tryConsume(1)).toBe(false) // and an actual consume rejects (still empty)
+    vi.spyOn(Date, 'now').mockReturnValue(start)
+    // The next refill at the original `now` advances tokens normally
+    // (1 second elapsed × 10 = +10 tokens, capped at maxTokens=10).
+    vi.advanceTimersByTime(1000)
+    let recovered = 0
+    while (rl.tryConsume(1)) recovered++
+    expect(recovered).toBe(10)
+  })
+
+  it('🔍 a future clock skew (jump forward) gives one big refill (DoS-relevant?)', () => {
+    const rl = new ConnectionRateLimiter(100, 10)
+    rl.tryConsume(100) // empty
+    // Jump forward 1 hour
+    vi.advanceTimersByTime(60 * 60 * 1000)
+    let got = 0
+    while (rl.tryConsume(1)) got++
+    // Bucket caps at 100, not 1000*60 — so this is fine.
+    expect(got).toBe(100)
+  })
+})
+
+describe('RateLimiterRegistry', () => {
+  it('returns the same limiter for the same id', () => {
+    const reg = new RateLimiterRegistry(10, 1)
+    const a = reg.get('conn-1')
+    const b = reg.get('conn-1')
+    expect(a).toBe(b)
+  })
+
+  it('returns different limiters for different ids', () => {
+    const reg = new RateLimiterRegistry(10, 1)
+    expect(reg.get('a')).not.toBe(reg.get('b'))
+  })
+
+  it('remove() actually removes (next get returns a new limiter)', () => {
+    const reg = new RateLimiterRegistry(10, 1)
+    const a = reg.get('conn-1')
+    a.tryConsume(10) // drain
+    reg.remove('conn-1')
+    const b = reg.get('conn-1')
+    expect(b).not.toBe(a)
+    // New limiter starts full
+    let got = 0
+    while (b.tryConsume(1)) got++
+    expect(got).toBe(10)
+  })
+
+  it('remove() on unknown id is a no-op', () => {
+    const reg = new RateLimiterRegistry(10, 1)
+    expect(() => reg.remove('ghost')).not.toThrow()
+  })
+
+  it('🔍 1000 unique ids never call remove() — memory leak vector', () => {
+    // The registry has no cap. Connection-id flood would grow `limiters` Map
+    // indefinitely. Documenting current behavior so we have a leak-aware test
+    // for the day a TTL or LRU is added.
+    const reg = new RateLimiterRegistry(10, 1)
+    for (let i = 0; i < 1000; i++) reg.get(`conn-${i}`)
+    // No explicit assertion on internals — the test acts as a documentation
+    // anchor. It will not fail until/unless someone adds a cap that should
+    // bound this number.
+    expect(true).toBe(true)
+  })
+})

--- a/packages/core/src/connection/RateLimiter.ts
+++ b/packages/core/src/connection/RateLimiter.ts
@@ -18,6 +18,11 @@ export class ConnectionRateLimiter {
   }
 
   tryConsume(count = 1): boolean {
+    // Reject pathological inputs early. Without this guard,
+    // tryConsume(-N) would REFUND tokens (a hostile client could exceed
+    // the cap), tryConsume(NaN) would silently corrupt the bucket via
+    // `tokens - NaN`, and tryConsume(Infinity) is meaningless.
+    if (!Number.isFinite(count) || count < 0) return false
     this.refill()
     if (this.tokens >= count) {
       this.tokens -= count
@@ -28,7 +33,12 @@ export class ConnectionRateLimiter {
 
   private refill(): void {
     const now = Date.now()
-    const elapsed = (now - this.lastRefill) / 1000
+    // Clamp elapsed to a non-negative value. If the system clock moved
+    // backwards (NTP adjustment, container clock drift, manual change),
+    // a negative elapsed would credit *negative* tokens, leaving the
+    // bucket below zero — every subsequent tryConsume would then reject
+    // even legitimate traffic. Treat backwards-clock as "no time passed".
+    const elapsed = Math.max(0, (now - this.lastRefill) / 1000)
     this.tokens = Math.min(this.maxTokens, this.tokens + elapsed * this.refillRate)
     this.lastRefill = now
   }


### PR DESCRIPTION
## Summary

Bug-hunt suite against three modules that had no adversarial coverage. Found **2 real bugs** in \`ConnectionRateLimiter\` and corrected them. Plus 50 unit tests across rate-limiter, binary protocol, and connection-manager edges.

## Bugs found & fixed

### 1. Negative-count refund (token cap bypass)
\`tryConsume(-3)\` returned \`true\` and **ADDED 3 tokens** to the bucket because \`this.tokens -= count\` with a negative count becomes \`+=\`. A hostile client could exceed \`maxTokens\` by passing a negative count over and over.

\`\`\`ts
// Fix:
if (!Number.isFinite(count) || count < 0) return false
\`\`\`

### 2. Backwards-clock corruption (permanent rate-limit lock)
\`refill()\` computed \`elapsed = (now - lastRefill) / 1000\`. If the system clock moved backwards (NTP adjustment, container clock drift, manual change), \`elapsed\` went negative and \`tokens\` were credited by a negative amount, leaving the bucket **permanently below zero**. Every subsequent \`tryConsume\` rejected even legitimate traffic.

\`\`\`ts
// Fix:
const elapsed = Math.max(0, (now - this.lastRefill) / 1000)
\`\`\`

A one-shot backward jump becomes a no-op refill; recovery is automatic on the next forward tick.

## What's covered (+50 tests)

| Suite | Tests | Catches |
|---|---|---|
| \`rate-limiter-edges\` | 14 | negative/NaN/Infinity/zero count, refill timing, both bug regressions, registry identity, leak vector |
| \`binary-protocol-edges\` | 16 | round-trip across sizes / byte values / UTF-8 headers, headerLength overflow (0xFFFFFFFF) must throw fast without allocating gigabytes, invalid JSON, truncated header, short tail |
| \`connection-manager-edges\` | 20 | maxConnections enforcement, duplicate-id overwrite documented, pool add/remove/cleanup completeness, cleanup removes from ALL pools, idempotent shutdown |

## Test plan

- [x] All 50 new tests pass
- [x] Full suite: **1358 passing** (was 1308, +50), Redis included, 0 failures
- [x] Typecheck clean
- [x] No breaking change — the bugs were silently broken behavior; the fixes restore correctness without altering documented contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)