### PR TITLE
feat: @fluxstack/spatial-room — interest management for game rooms

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -235,6 +235,18 @@
         "ioredis": ">=5.0.0",
       },
     },
+    "packages/spatial-room": {
+      "name": "@fluxstack/spatial-room",
+      "version": "0.9.0",
+      "devDependencies": {
+        "tsup": "^8.0.0",
+        "typescript": "^5.3.3",
+        "vitest": "^3.2.4",
+      },
+      "peerDependencies": {
+        "@fluxstack/live": "^0.9.0",
+      },
+    },
     "packages/vue": {
       "name": "@fluxstack/live-vue",
       "version": "0.9.0",
@@ -360,6 +372,8 @@
     "@fluxstack/live-vue": ["@fluxstack/live-vue@workspace:packages/vue"],
 
     "@fluxstack/plugin-kit": ["@fluxstack/plugin-kit@workspace:packages/plugin-kit"],
+
+    "@fluxstack/spatial-room": ["@fluxstack/spatial-room@workspace:packages/spatial-room"],
 
     "@ioredis/commands": ["@ioredis/commands@1.5.1", "", {}, "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="],
 

--- a/packages/core/src/component/context.ts
+++ b/packages/core/src/component/context.ts
@@ -14,6 +14,8 @@ export interface LiveRoomManagerInterface {
   leaveRoom(componentId: string, roomId: string, leaveReason?: 'leave' | 'disconnect' | 'cleanup'): void | Promise<void>
   cleanupComponent(componentId: string): void | Promise<void>
   emitToRoom(roomId: string, event: string, data: any, excludeComponentId?: string): number
+  /** Emit to a specific subset of room members. Used by interest-management plugins. */
+  emitToRoomMembers?(roomId: string, members: Iterable<string>, event: string, data: any): number
   setRoomState(roomId: string, updates: any, excludeComponentId?: string): void
   getRoomState<TState = any>(roomId: string): TState
   isInRoom(componentId: string, roomId: string): boolean

--- a/packages/core/src/rooms/LiveRoomManager.ts
+++ b/packages/core/src/rooms/LiveRoomManager.ts
@@ -519,6 +519,58 @@ export class LiveRoomManager {
   }
 
   /**
+   * Emit an event to a SUBSET of room members (filtered by componentId).
+   *
+   * Used by interest-management plugins (e.g. @fluxstack/spatial-room) to
+   * deliver an event only to nearby members. The set must contain valid
+   * componentIds already joined to the room; unknown ids are skipped.
+   *
+   * Skips `onEvent` lifecycle, the server-side RoomEventBus, and cluster
+   * pubsub — those are global signals and would defeat the filter.
+   *
+   * @returns number of members the event was sent to
+   */
+  emitToRoomMembers(
+    roomId: string,
+    members: Iterable<string>,
+    event: string,
+    data: any,
+  ): number {
+    const room = this.rooms.get(roomId)
+    if (!room) return 0
+    const now = Date.now()
+    room.lastActivity = now
+
+    let sent = 0
+    if (room.codec) {
+      // Binary path: encode payload once, build shared tail, prepend per-member header.
+      const payload = room.codec.encode(data)
+      const tail = buildRoomFrameTail(roomId, event, payload)
+      for (const cid of members) {
+        const member = room.members.get(cid)
+        if (!member || member.ws.readyState !== 1) continue
+        const frame = prependMemberHeader(BINARY_ROOM_EVENT, cid, tail)
+        sendBinaryImmediate(member.ws, frame)
+        sent++
+      }
+    } else {
+      // JSON path: build template once, splice componentId per member.
+      const message = { type: 'ROOM_EVENT', componentId: '', roomId, event, data, timestamp: now }
+      const { componentId: _, ...rest } = message
+      const jsonBody = JSON.stringify(rest)
+      const prefix = '{"componentId":"'
+      const suffix = '",' + jsonBody.slice(1)
+      for (const cid of members) {
+        const member = room.members.get(cid)
+        if (!member || member.ws.readyState !== 1) continue
+        queuePreSerialized(member.ws, prefix + cid + suffix)
+        sent++
+      }
+    }
+    return sent
+  }
+
+  /**
    * Strip keys that the client is never allowed to set on room state:
    *   - prototype-pollution keys (`__proto__`, `constructor`, `prototype`)
    *   - `$`-prefixed keys (server-only convention, mirrors PROPERTY_UPDATE rule)

--- a/packages/spatial-room/README.md
+++ b/packages/spatial-room/README.md
@@ -1,0 +1,160 @@
+# @fluxstack/spatial-room
+
+Interest management for `@fluxstack/live` rooms. Reduces broadcast cost from
+**O(N)** to **O(visible cells)** for games where players only need updates
+from nearby peers.
+
+Two ready-to-use room classes:
+
+- **`SpatialLiveRoom`** — general 2D/3D grid. Top-down RPG, side-scroller,
+  `.io` games, MMO maps.
+- **`ChunkRoom`** — specialised 3D voxel/Minecraft-style chunks. Default
+  `cellSize=16` (Minecraft standard chunk), default view distance 1
+  (3×3×3 = 27 chunks visible).
+
+## Why
+
+A LiveRoom with 1000 members fanouts every `emit()` to **all 1000** WebSocket
+connections. For chat/state updates that's fine; for player movement at
+30/60 Hz it crushes the server. Spatial rooms keep an internal grid and only
+deliver to members in the surrounding cells of the sender.
+
+Measured impact (see tests):
+
+- **2D, 1000 players in 1000×1000 world, cellSize=100**: broadcast reaches
+  **86 peers (8.6% of room)** instead of 999 (91% reduction).
+- **3D voxel, 1000 players in 30³ chunks, view distance 1**: broadcast reaches
+  **33 peers (3.3% of room)** instead of 999 (97% reduction).
+
+## Install
+
+```bash
+bun add @fluxstack/spatial-room
+```
+
+## Quick start — 2D top-down
+
+```ts
+import { SpatialLiveRoom } from '@fluxstack/spatial-room'
+
+interface GameState {
+  players: Record<string, { x: number; y: number; hp: number }>
+}
+
+interface GameEvents {
+  moved: { id: string; x: number; y: number }
+  shot:  { from: string; angle: number }
+}
+
+class GameRoom extends SpatialLiveRoom<GameState, any, GameEvents> {
+  static roomName = 'game'
+  static defaultState: GameState = { players: {} }
+  static spatial = {
+    dimensions: 2,
+    cellSize: 100,      // world units per cell
+    defaultRange: 1,    // 3×3 visible neighbourhood
+  }
+
+  movePlayer(componentId: string, x: number, y: number) {
+    this.setMemberPosition(componentId, [x, y])
+    this.state.players[componentId] = { ...this.state.players[componentId]!, x, y }
+    // Only players in the same or adjacent cells receive this:
+    this.emitNearby(componentId, 'moved', { id: componentId, x, y })
+  }
+}
+```
+
+## Quick start — 3D voxel / Minecraft
+
+```ts
+import { ChunkRoom } from '@fluxstack/spatial-room'
+
+class WorldRoom extends ChunkRoom<{}, any, {
+  blockPlaced: { x: number; y: number; z: number; type: number }
+}> {
+  static roomName = 'world'
+  static defaultState = {}
+  // Defaults: 3D, cellSize=16, range=1 → 27 chunks visible. Override
+  // `static spatial = { cellSize: ..., defaultRange: ... }` if needed.
+
+  placeBlock(componentId: string, x: number, y: number, z: number, type: number) {
+    this.setMemberWorldPosition(componentId, x, y, z) // updates the grid
+    // Only players in nearby chunks receive this:
+    this.emitInChunkRange(componentId, 'blockPlaced', { x, y, z, type })
+  }
+}
+```
+
+## API
+
+### `SpatialLiveRoom` (extends `LiveRoom`)
+
+| method | description |
+|---|---|
+| `setMemberPosition(id, [x, y]` or `[x, y, z])` | place / move a member in the grid. Idempotent; returns `true` if the member crossed a cell boundary. |
+| `getMemberCell(id)` | current cell key (string), or `undefined` |
+| `emitNearby(senderId, event, data, opts?)` | broadcast only to members within `opts.range` cells of the sender (default `defaultRange`). Sender excluded unless `includeSelf`. Falls back to global `emit()` if sender has no recorded position. |
+| `emitAtPosition([x, y], event, data, opts?)` | broadcast to members near an arbitrary world point (no sender — useful for "explosion at X") |
+| `getVisibleMembers(id, range?)` | diagnostic: who can see this member |
+| `getOccupiedCellCount()` | diagnostic: populated cells — useful to tune `cellSize` |
+
+The `grid` property exposes the underlying `SpatialGrid` for advanced
+use (custom queries, manual indexing).
+
+### `ChunkRoom` (extends `SpatialLiveRoom` with 3D defaults)
+
+Adds:
+
+| method | description |
+|---|---|
+| `setMemberWorldPosition(id, x, y, z)` | same as `setMemberPosition` but with explicit args |
+| `setMemberChunk(id, [cx, cy, cz])` | place a member by chunk coord (places at chunk origin) |
+| `getMemberChunk(id)` | current chunk coord `[cx, cy, cz]` or `undefined` |
+| `emitInChunkRange(senderId, event, data, opts?)` | alias of `emitNearby` with game-y naming |
+| `emitAtChunk([cx, cy, cz], event, data, opts?)` | broadcast to members near a chunk (server-originated events) |
+
+Plus the helper functions:
+
+- `chunkToWorld([cx, cy, cz], chunkSize)` → world `[x, y, z]` at chunk origin
+- `worldToChunk([x, y, z], chunkSize)` → containing chunk `[cx, cy, cz]`
+
+### `SpatialGrid<M>` (low-level)
+
+If you want spatial indexing **without** the LiveRoom integration (e.g. for
+bots / NPCs / server-side AI):
+
+```ts
+import { SpatialGrid } from '@fluxstack/spatial-room'
+
+const grid = new SpatialGrid<string>({ dimensions: 2, cellSize: 50 })
+grid.setPosition('npc-1', [120, 80])
+grid.setPosition('npc-2', [125, 85])
+grid.queryNear([100, 100], 1)  // → Set { 'npc-1', 'npc-2' }
+grid.queryNearMember('npc-1')  // → Set { 'npc-2' } (excludes self)
+```
+
+## Tuning `cellSize`
+
+Rule of thumb: pick `cellSize` so that one cell contains the **interaction
+range** of a player. For a top-down shooter with bullets visible up to 500
+units away, `cellSize=500` and `range=1` (3×3 = 1500 units of coverage) is
+a good start.
+
+Diagnostic: if `room.getOccupiedCellCount()` stays in single digits with
+hundreds of players, cells are **too big** (everyone in the same cell —
+filter does nothing). If it explodes to thousands with few players, cells
+are **too small** (lookups walk many empty cells).
+
+## What it does NOT do
+
+- **State broadcast**: `setState` still goes to all members. Interest
+  management here is for **events** (`emit`), not the shared room state.
+  Most games keep state as "world data" (replicated everywhere) and use
+  events for per-player updates anyway.
+- **Custom shapes**: only axis-aligned cells. No circles, no view cones,
+  no occlusion. Build those on top by combining `queryNear` results with
+  your own filters.
+- **Dynamic load balancing**: cells are uniform. If you have a dense club
+  next to an empty desert, the club's cell will be a hotspot. For that
+  case, look at quadtree / R-tree libraries — this package intentionally
+  stays simple.

--- a/packages/spatial-room/package.json
+++ b/packages/spatial-room/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@fluxstack/spatial-room",
+  "version": "0.9.0",
+  "description": "Spatial LiveRoom with grid-based interest management. Reduces broadcast cost from O(N) to O(visible cells) for games where players only need updates from nearby peers.",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "bun": "./src/index.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist", "src"],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@fluxstack/live": "^0.9.0"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/spatial-room/src/ChunkRoom.ts
+++ b/packages/spatial-room/src/ChunkRoom.ts
@@ -1,0 +1,108 @@
+// ChunkRoom — 3D block-grid LiveRoom for voxel/Minecraft-style worlds.
+//
+// Specialisation of SpatialLiveRoom with:
+//   - Default 3D + cellSize = 16 (standard Minecraft chunk size).
+//   - Helpers that work in chunk coordinates ([cx, cy, cz]) as well as
+//     world coordinates: many voxel games naturally store player chunk
+//     positions, not world positions.
+//   - emitInChunk / emitNearChunks for the common "broadcast within chunk
+//     load distance" pattern.
+
+import { SpatialLiveRoom, type SpatialRoomConfig } from './SpatialLiveRoom'
+import type { Vec3 } from './SpatialGrid'
+
+export interface ChunkCoord extends Vec3 {}
+
+/**
+ * Convert chunk coordinates to a world-space position at the chunk's
+ * origin. Useful when calling APIs that take world positions.
+ */
+export function chunkToWorld(coord: ChunkCoord, chunkSize: number): Vec3 {
+  return [coord[0] * chunkSize, coord[1] * chunkSize, coord[2] * chunkSize]
+}
+
+/**
+ * Convert a world-space position to its containing chunk coordinate.
+ */
+export function worldToChunk(pos: Vec3, chunkSize: number): Vec3 {
+  return [Math.floor(pos[0] / chunkSize), Math.floor(pos[1] / chunkSize), Math.floor(pos[2] / chunkSize)]
+}
+
+export abstract class ChunkRoom<
+  TState extends Record<string, any> = Record<string, any>,
+  TMeta extends Record<string, any> = Record<string, any>,
+  TEvents extends Record<string, any> = Record<string, any>,
+> extends SpatialLiveRoom<TState, TMeta, TEvents> {
+  /**
+   * Default chunk config. Subclasses can override `spatial` to change
+   * chunk size or view distance.
+   *
+   * chunkSize=16 matches Minecraft's standard chunk; view distance of 1
+   * cell on each side = 3×3×3 = 27 chunks visible (the sender's chunk
+   * + 26 neighbours), which is roughly Minecraft's "view-distance: 2"
+   * setting in terms of chunks reached.
+   */
+  static spatial: SpatialRoomConfig = {
+    dimensions: 3,
+    cellSize: 16,
+    defaultRange: 1,
+  }
+
+  /** Convenience: place a player by world position. Same as setMemberPosition. */
+  setMemberWorldPosition(componentId: string, x: number, y: number, z: number): boolean {
+    return this.setMemberPosition(componentId, [x, y, z])
+  }
+
+  /** Place a player by chunk coordinate (and offset 0 inside the chunk). */
+  setMemberChunk(componentId: string, chunk: ChunkCoord): boolean {
+    const ctor = this.constructor as typeof ChunkRoom
+    const size = ctor.spatial.cellSize ?? 16
+    return this.setMemberPosition(componentId, chunkToWorld(chunk, size))
+  }
+
+  /** The chunk coord this player currently occupies, or undefined. */
+  getMemberChunk(componentId: string): ChunkCoord | undefined {
+    const key = this.getMemberCell(componentId)
+    if (!key) return undefined
+    const parts = key.split(':').map(Number)
+    if (parts.length !== 3 || parts.some(n => !Number.isFinite(n))) return undefined
+    return [parts[0]!, parts[1]!, parts[2]!]
+  }
+
+  /**
+   * Broadcast an event only to players in the same chunk + the neighbouring
+   * chunks (3×3×3 cube by default). The sender is excluded by default.
+   * If the sender has no recorded chunk, falls back to a global emit.
+   */
+  emitInChunkRange<K extends keyof TEvents & string>(
+    senderComponentId: string,
+    event: K,
+    data: TEvents[K],
+    options?: { range?: number; includeSelf?: boolean },
+  ): number {
+    // Same semantics as emitNearby — provided under a more game-y name.
+    return this.emitNearby(senderComponentId, event, data, options)
+  }
+
+  /**
+   * Broadcast an event to all players in a specific chunk neighbourhood
+   * (no sender — pure world-event like "block placed at chunk X").
+   */
+  emitAtChunk<K extends keyof TEvents & string>(
+    chunk: ChunkCoord,
+    event: K,
+    data: TEvents[K],
+    options?: { range?: number },
+  ): number {
+    const ctor = this.constructor as typeof ChunkRoom
+    const size = ctor.spatial.cellSize ?? 16
+    // Use chunk centre for the query so range=1 picks up the chunk itself
+    // plus its 26 neighbours, regardless of which corner the player is in.
+    const centre: Vec3 = [
+      chunk[0] * size + size / 2,
+      chunk[1] * size + size / 2,
+      chunk[2] * size + size / 2,
+    ]
+    return this.emitAtPosition(centre, event, data, options)
+  }
+}

--- a/packages/spatial-room/src/SpatialGrid.ts
+++ b/packages/spatial-room/src/SpatialGrid.ts
@@ -1,0 +1,211 @@
+// SpatialGrid — uniform 2D/3D cell index for proximity queries.
+//
+// Each member occupies exactly one cell at any moment. Lookups by position
+// return the union of all members in the surrounding `range` cells
+// (3x3 for range=1 in 2D, 27 for range=1 in 3D, 5x5/125 for range=2, etc.).
+//
+// Cell key is a compact string ("x:y" or "x:y:z"). Maps are kept symmetric
+// (member→cell + cell→members) so moves and removes are O(1).
+//
+// This module is pure data structure — no LiveRoom/WS coupling. SpatialLiveRoom
+// composes it. Designed for hot-path use: getters allocate as little as
+// possible and never traverse cells outside the query range.
+
+export type Vec2 = readonly [number, number]
+export type Vec3 = readonly [number, number, number]
+export type Position = Vec2 | Vec3
+
+export interface SpatialGridOptions {
+  /** 2 (Vec2) or 3 (Vec3). Default: 2. */
+  dimensions?: 2 | 3
+  /** World-space size of one cell along each axis. Default: 100. */
+  cellSize?: number
+  /**
+   * Default radius (in cells) returned by neighborCells/queryNear when the
+   * caller doesn't pass one. 1 → 3×3 (2D) / 3×3×3 (3D). Default: 1.
+   */
+  defaultRange?: number
+}
+
+export class SpatialGrid<M = string> {
+  readonly dimensions: 2 | 3
+  readonly cellSize: number
+  readonly defaultRange: number
+
+  /** cellKey → Set of members in that cell */
+  private cells = new Map<string, Set<M>>()
+  /** member → current cellKey (so a move can leave the old cell in O(1)) */
+  private memberCell = new Map<M, string>()
+
+  constructor(options: SpatialGridOptions = {}) {
+    this.dimensions = options.dimensions ?? 2
+    this.cellSize = options.cellSize ?? 100
+    this.defaultRange = options.defaultRange ?? 1
+    if (this.cellSize <= 0 || !Number.isFinite(this.cellSize)) {
+      throw new Error('SpatialGrid: cellSize must be a positive finite number')
+    }
+    if (this.defaultRange < 0 || !Number.isInteger(this.defaultRange)) {
+      throw new Error('SpatialGrid: defaultRange must be a non-negative integer')
+    }
+  }
+
+  /** Convert world position to integer cell coords. */
+  private toCellCoords(pos: Position): number[] {
+    const out = new Array(this.dimensions)
+    for (let i = 0; i < this.dimensions; i++) {
+      out[i] = Math.floor(pos[i]! / this.cellSize)
+    }
+    return out
+  }
+
+  private cellKey(coords: number[]): string {
+    return this.dimensions === 2
+      ? `${coords[0]}:${coords[1]}`
+      : `${coords[0]}:${coords[1]}:${coords[2]}`
+  }
+
+  /** Direct world-position → cellKey shortcut. */
+  positionToCellKey(pos: Position): string {
+    return this.cellKey(this.toCellCoords(pos))
+  }
+
+  /**
+   * Place or move a member to the given position. O(1) — removes from old
+   * cell (if any) and adds to the new one. Returns true if the member
+   * crossed a cell boundary (i.e. its visible neighborhood may have changed).
+   */
+  setPosition(member: M, pos: Position): boolean {
+    const newKey = this.positionToCellKey(pos)
+    const oldKey = this.memberCell.get(member)
+    if (oldKey === newKey) return false
+
+    if (oldKey !== undefined) {
+      const oldCell = this.cells.get(oldKey)
+      if (oldCell) {
+        oldCell.delete(member)
+        if (oldCell.size === 0) this.cells.delete(oldKey)
+      }
+    }
+
+    let cell = this.cells.get(newKey)
+    if (!cell) {
+      cell = new Set()
+      this.cells.set(newKey, cell)
+    }
+    cell.add(member)
+    this.memberCell.set(member, newKey)
+    return true
+  }
+
+  /** Remove a member entirely. O(1). No-op if the member isn't tracked. */
+  remove(member: M): void {
+    const key = this.memberCell.get(member)
+    if (key === undefined) return
+    this.memberCell.delete(member)
+    const cell = this.cells.get(key)
+    if (cell) {
+      cell.delete(member)
+      if (cell.size === 0) this.cells.delete(key)
+    }
+  }
+
+  /** Current cellKey of a member, or undefined if not tracked. */
+  getCell(member: M): string | undefined {
+    return this.memberCell.get(member)
+  }
+
+  /** Whether a member has a known position. */
+  has(member: M): boolean {
+    return this.memberCell.has(member)
+  }
+
+  /** Total tracked members. */
+  get size(): number {
+    return this.memberCell.size
+  }
+
+  /**
+   * Yield every cell key within `range` cells of `pos` (inclusive).
+   * range=0 yields just the cell containing pos. range=1 yields a 3×3 (2D)
+   * or 3×3×3 (3D) cube. Caller iterates lazily — no array materialised.
+   */
+  *neighborCells(pos: Position, range: number = this.defaultRange): Generator<string> {
+    const c = this.toCellCoords(pos)
+    if (this.dimensions === 2) {
+      for (let dx = -range; dx <= range; dx++) {
+        for (let dy = -range; dy <= range; dy++) {
+          yield `${c[0]! + dx}:${c[1]! + dy}`
+        }
+      }
+    } else {
+      for (let dx = -range; dx <= range; dx++) {
+        for (let dy = -range; dy <= range; dy++) {
+          for (let dz = -range; dz <= range; dz++) {
+            yield `${c[0]! + dx}:${c[1]! + dy}:${c[2]! + dz}`
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Collect all members within `range` cells of `pos`. Useful for broadcast:
+   * the caller iterates the returned Set once. We collect into a Set (not
+   * an array) to deduplicate when callers pass a position that maps to a
+   * cell that overlaps with the sender's own — they normally want to send
+   * to "everyone visible", with the sender filtering itself separately.
+   */
+  queryNear(pos: Position, range: number = this.defaultRange): Set<M> {
+    const result = new Set<M>()
+    for (const key of this.neighborCells(pos, range)) {
+      const cell = this.cells.get(key)
+      if (cell) for (const m of cell) result.add(m)
+    }
+    return result
+  }
+
+  /**
+   * Collect all members within `range` cells of `member`'s current position.
+   * Convenience wrapper for the common pattern "broadcast to peers near me".
+   * If `excludeSelf` is true (default), the member itself is removed from
+   * the result.
+   */
+  queryNearMember(member: M, range: number = this.defaultRange, excludeSelf = true): Set<M> {
+    const myKey = this.memberCell.get(member)
+    if (myKey === undefined) return new Set()
+    const result = new Set<M>()
+    // Reconstruct position from cellKey — avoids storing positions if the
+    // caller doesn't keep them around. We just need the cell coords.
+    const coords = myKey.split(':').map(Number)
+    if (this.dimensions === 2) {
+      for (let dx = -range; dx <= range; dx++) {
+        for (let dy = -range; dy <= range; dy++) {
+          const cell = this.cells.get(`${coords[0]! + dx}:${coords[1]! + dy}`)
+          if (cell) for (const m of cell) result.add(m)
+        }
+      }
+    } else {
+      for (let dx = -range; dx <= range; dx++) {
+        for (let dy = -range; dy <= range; dy++) {
+          for (let dz = -range; dz <= range; dz++) {
+            const cell = this.cells.get(`${coords[0]! + dx}:${coords[1]! + dy}:${coords[2]! + dz}`)
+            if (cell) for (const m of cell) result.add(m)
+          }
+        }
+      }
+    }
+    if (excludeSelf) result.delete(member)
+    return result
+  }
+
+  /** Number of populated cells. Useful for diagnostics. */
+  get cellCount(): number {
+    return this.cells.size
+  }
+
+  /** Reset all state. */
+  clear(): void {
+    this.cells.clear()
+    this.memberCell.clear()
+  }
+}

--- a/packages/spatial-room/src/SpatialLiveRoom.ts
+++ b/packages/spatial-room/src/SpatialLiveRoom.ts
@@ -1,0 +1,152 @@
+// SpatialLiveRoom — LiveRoom with a per-room spatial grid for interest
+// management. Members declare a position via setMemberPosition(); broadcasts
+// done via emitNearby() reach only members in the surrounding cells instead
+// of every member in the room.
+//
+// Drop-in: extend SpatialLiveRoom instead of LiveRoom. The existing emit() /
+// setState() / onJoin() / etc. work unchanged. Spatial filtering is opt-in
+// per emit (you pick which events go through the filter; chat-style global
+// events keep using emit()).
+
+import { LiveRoom, type RoomLeaveContext } from '@fluxstack/live'
+import type { LiveRoomManager } from '@fluxstack/live'
+import { SpatialGrid, type Position, type SpatialGridOptions } from './SpatialGrid'
+
+export interface SpatialRoomConfig extends SpatialGridOptions {}
+
+/**
+ * Internal interface for the bits of LiveRoomManager we touch. The full
+ * manager is much bigger; we only need the per-member emit added in core.
+ */
+interface ManagerWithMembers {
+  emitToRoomMembers(
+    roomId: string,
+    members: Iterable<string>,
+    event: string,
+    data: any,
+  ): number
+}
+
+export abstract class SpatialLiveRoom<
+  TState extends Record<string, any> = Record<string, any>,
+  TMeta extends Record<string, any> = Record<string, any>,
+  TEvents extends Record<string, any> = Record<string, any>,
+> extends LiveRoom<TState, TMeta, TEvents> {
+  /**
+   * Spatial configuration. Subclasses override with their own grid sizing.
+   * Defaults: 2D, 100-unit cells, range=1 (3×3 neighborhood).
+   */
+  static spatial: SpatialRoomConfig = {}
+
+  /** Per-instance grid. Initialised lazily on first position write. */
+  private _grid: SpatialGrid<string> | null = null
+
+  /** Lazy grid getter so unused features cost nothing. */
+  public get grid(): SpatialGrid<string> {
+    if (!this._grid) {
+      const ctor = this.constructor as typeof SpatialLiveRoom
+      this._grid = new SpatialGrid<string>(ctor.spatial ?? {})
+    }
+    return this._grid
+  }
+
+  /**
+   * Place or move a member in the grid. Call this whenever a player's
+   * position changes (typically inside an action handler).
+   *
+   * Idempotent — calling with the same cell as before is a no-op.
+   *
+   * @returns true if the member crossed a cell boundary (useful if you
+   *          want to notify the moving player about new visible peers).
+   */
+  public setMemberPosition(componentId: string, pos: Position): boolean {
+    return this.grid.setPosition(componentId, pos)
+  }
+
+  /**
+   * Get the current cell key of a member, or undefined if no position
+   * has been set for them. Useful for diagnostics.
+   */
+  public getMemberCell(componentId: string): string | undefined {
+    return this._grid?.getCell(componentId)
+  }
+
+  /**
+   * Broadcast an event to members near the sender. The sender itself is
+   * excluded by default (matches the LiveRoom.emit convention).
+   *
+   * If the sender has no recorded position, falls back to a global emit
+   * (so an early call before setMemberPosition still works).
+   *
+   * @returns number of members notified
+   */
+  emitNearby<K extends keyof TEvents & string>(
+    senderComponentId: string,
+    event: K,
+    data: TEvents[K],
+    options?: { range?: number; includeSelf?: boolean },
+  ): number {
+    const range = options?.range ?? this.grid.defaultRange
+    const includeSelf = options?.includeSelf ?? false
+    const grid = this._grid
+    if (!grid || !grid.has(senderComponentId)) {
+      // No position recorded — fall back to global broadcast so the caller
+      // still sees the event delivered. excludeSelf default matches emit().
+      return this.emit(event, data)
+    }
+    const targets = grid.queryNearMember(senderComponentId, range, !includeSelf)
+    return (this._manager as unknown as ManagerWithMembers)
+      .emitToRoomMembers(this.id, targets, event, data)
+  }
+
+  /**
+   * Broadcast an event to members near an arbitrary world position
+   * (independent of any sender). Useful for "explosion at (x,y)" events
+   * that originate from the server, not a player.
+   *
+   * @returns number of members notified
+   */
+  emitAtPosition<K extends keyof TEvents & string>(
+    pos: Position,
+    event: K,
+    data: TEvents[K],
+    options?: { range?: number },
+  ): number {
+    const range = options?.range ?? this.grid.defaultRange
+    const targets = this.grid.queryNear(pos, range)
+    return (this._manager as unknown as ManagerWithMembers)
+      .emitToRoomMembers(this.id, targets, event, data)
+  }
+
+  /**
+   * Hook into LiveRoom's onLeave to automatically remove the member from
+   * the spatial grid. Subclasses that override onLeave must call super.
+   */
+  override onLeave(ctx: RoomLeaveContext): void | Promise<void> {
+    this._grid?.remove(ctx.componentId)
+  }
+
+  /**
+   * Diagnostics: members currently visible from a given sender.
+   * Exposed so dev tooling/tests can inspect the interest set.
+   */
+  getVisibleMembers(senderComponentId: string, range?: number): Set<string> {
+    if (!this._grid) return new Set()
+    return this._grid.queryNearMember(
+      senderComponentId,
+      range ?? this._grid.defaultRange,
+      true,
+    )
+  }
+
+  /**
+   * Diagnostics: total cells currently occupied (sparse — empty cells are
+   * not stored). Use to pick a sensible cellSize: if cellCount stays in
+   * the single digits while you have hundreds of players, cells are too
+   * big and the filter does little; if it explodes to thousands with few
+   * players, cells are too small and lookups walk many empties.
+   */
+  getOccupiedCellCount(): number {
+    return this._grid?.cellCount ?? 0
+  }
+}

--- a/packages/spatial-room/src/__tests__/ChunkRoom.test.ts
+++ b/packages/spatial-room/src/__tests__/ChunkRoom.test.ts
@@ -1,0 +1,246 @@
+// ChunkRoom — voxel/Minecraft-style 3D chunked room.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { LiveRoomManager, RoomRegistry, RoomEventBus } from '@fluxstack/live'
+import { ChunkRoom, chunkToWorld, worldToChunk } from '../ChunkRoom'
+
+type AnyWS = any
+
+function mockWs(id: string) {
+  const sent: any[] = []
+  const data = {
+    connectionId: id, components: new Map(), subscriptions: new Set(),
+    connectedAt: new Date(), userId: undefined,
+    authContext: { authenticated: false, session: undefined,
+      hasRole: () => false, hasAnyRole: () => false, hasAllRoles: () => false,
+      hasPermission: () => false, hasAllPermissions: () => false, hasAnyPermission: () => false } as any,
+  }
+  return {
+    send: (m: any) => { sent.push(m) },
+    close: () => {},
+    data, remoteAddress: '127.0.0.1', readyState: 1 as const, _sent: sent,
+  } as AnyWS
+}
+
+interface VoxelState { blocks: Record<string, number> }
+
+class MinecraftRoom extends ChunkRoom<VoxelState, any, {
+  blockPlaced: { x: number; y: number; z: number; type: number }
+  chat: { from: string; text: string }
+}> {
+  static roomName = 'mc'
+  static defaultState: VoxelState = { blocks: {} }
+  // Override to override chunk size if needed; default is 16 (Minecraft standard).
+}
+
+class FineGrainedRoom extends ChunkRoom<{}, any, { tick: { n: number } }> {
+  static roomName = 'fine'
+  static defaultState = {}
+  static spatial = { dimensions: 3 as const, cellSize: 8, defaultRange: 2 }
+}
+
+function makeManager() {
+  const mgr = new LiveRoomManager(new RoomEventBus())
+  const reg = new RoomRegistry()
+  mgr.roomRegistry = reg
+  return { mgr, reg }
+}
+
+let errSpy: ReturnType<typeof vi.spyOn>
+beforeEach(() => { errSpy = vi.spyOn(console, 'error').mockImplementation(() => {}) })
+afterEach(() => { errSpy?.mockRestore() })
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('chunkToWorld / worldToChunk helpers', () => {
+  it('chunkToWorld returns chunk origin', () => {
+    expect(chunkToWorld([0, 0, 0], 16)).toEqual([0, 0, 0])
+    expect(chunkToWorld([1, 2, -1], 16)).toEqual([16, 32, -16])
+  })
+
+  it('worldToChunk floors to chunk coord', () => {
+    expect(worldToChunk([0, 0, 0], 16)).toEqual([0, 0, 0])
+    expect(worldToChunk([15.99, 0, 0], 16)).toEqual([0, 0, 0])
+    expect(worldToChunk([16, 0, 0], 16)).toEqual([1, 0, 0])
+    expect(worldToChunk([-1, 0, 0], 16)).toEqual([-1, 0, 0]) // floor(-0.0625)=-1
+  })
+
+  it('round-trip world → chunk → world lands at the chunk origin', () => {
+    expect(chunkToWorld(worldToChunk([100, 200, 300], 16), 16)).toEqual([96, 192, 288])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('ChunkRoom — defaults', () => {
+  it('defaults to 3D, cellSize 16, range 1 (3×3×3 = 27 chunks visible)', () => {
+    expect(ChunkRoom.spatial.dimensions).toBe(3)
+    expect(ChunkRoom.spatial.cellSize).toBe(16)
+    expect(ChunkRoom.spatial.defaultRange).toBe(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('ChunkRoom — member placement', () => {
+  it('setMemberWorldPosition and setMemberChunk both place the player', async () => {
+    const { mgr, reg } = makeManager()
+    reg.register(MinecraftRoom as any)
+    await mgr.joinRoom('alice', 'mc:r', mockWs('alice'))
+
+    const room = (mgr as any).rooms.get('mc:r').instance as MinecraftRoom
+
+    room.setMemberWorldPosition('alice', 0, 64, 0)
+    expect(room.getMemberChunk('alice')).toEqual([0, 4, 0]) // y=64 / 16 = chunk 4
+
+    room.setMemberChunk('alice', [3, 0, -2])
+    expect(room.getMemberChunk('alice')).toEqual([3, 0, -2])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('ChunkRoom — emitInChunkRange', () => {
+  it('only delivers to players within chunk view distance', async () => {
+    const { mgr, reg } = makeManager()
+    reg.register(MinecraftRoom as any)
+    const wsA = mockWs('A')
+    const wsNeighbor = mockWs('Neighbor')
+    const wsFar = mockWs('Far')
+    await mgr.joinRoom('A', 'mc:r', wsA)
+    await mgr.joinRoom('Neighbor', 'mc:r', wsNeighbor)
+    await mgr.joinRoom('Far', 'mc:r', wsFar)
+
+    const room = (mgr as any).rooms.get('mc:r').instance as MinecraftRoom
+    room.setMemberChunk('A', [0, 0, 0])
+    room.setMemberChunk('Neighbor', [1, 0, 0])    // adjacent chunk
+    room.setMemberChunk('Far', [10, 10, 10])      // way out of range
+
+    wsA._sent.length = 0
+    wsNeighbor._sent.length = 0
+    wsFar._sent.length = 0
+
+    const sent = room.emitInChunkRange('A', 'blockPlaced', { x: 1, y: 65, z: 1, type: 1 })
+    expect(sent).toBe(1) // only Neighbor
+    expect(wsNeighbor._sent.length).toBe(1)
+    expect(wsFar._sent.length).toBe(0)
+  })
+
+  it('view distance >1 reaches farther neighbours', async () => {
+    const { mgr, reg } = makeManager()
+    reg.register(MinecraftRoom as any)
+    const wsList = ['A', 'B', 'C'].map(mockWs)
+    for (const ws of wsList) await mgr.joinRoom(ws.data.connectionId, 'mc:r', ws)
+
+    const room = (mgr as any).rooms.get('mc:r').instance as MinecraftRoom
+    room.setMemberChunk('A', [0, 0, 0])
+    room.setMemberChunk('B', [2, 0, 0])  // 2 chunks away — out of range 1
+    room.setMemberChunk('C', [3, 0, 0])  // 3 chunks away
+
+    for (const ws of wsList) ws._sent.length = 0
+
+    // With range=2, B should be reached (2 cells), C should not (3 cells).
+    const sent = room.emitInChunkRange('A', 'chat', { from: 'A', text: 'hi' }, { range: 2 })
+    expect(sent).toBe(1)
+    expect(wsList[1]!._sent.length).toBe(1) // B
+    expect(wsList[2]!._sent.length).toBe(0) // C
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('ChunkRoom — emitAtChunk (no sender, "block placed at chunk X")', () => {
+  it('reaches players near a given chunk', async () => {
+    const { mgr, reg } = makeManager()
+    reg.register(MinecraftRoom as any)
+    const wsA = mockWs('A')
+    const wsB = mockWs('B')
+    await mgr.joinRoom('A', 'mc:r', wsA)
+    await mgr.joinRoom('B', 'mc:r', wsB)
+
+    const room = (mgr as any).rooms.get('mc:r').instance as MinecraftRoom
+    room.setMemberChunk('A', [5, 0, 5])
+    room.setMemberChunk('B', [100, 0, 100])
+
+    wsA._sent.length = 0
+    wsB._sent.length = 0
+
+    // Server places a block at chunk [4, 0, 5] (adjacent to A).
+    const sent = room.emitAtChunk([4, 0, 5], 'blockPlaced', { x: 70, y: 64, z: 80, type: 5 })
+    expect(sent).toBe(1)
+    expect(wsA._sent.length).toBe(1)
+    expect(wsB._sent.length).toBe(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('ChunkRoom — fine-grained cellSize for high-density games', () => {
+  it('smaller cellSize + bigger range still filters correctly', async () => {
+    const { mgr, reg } = makeManager()
+    reg.register(FineGrainedRoom as any)
+    const wsA = mockWs('A')
+    const wsClose = mockWs('Close')
+    const wsFar = mockWs('Far')
+    await mgr.joinRoom('A', 'fine:r', wsA)
+    await mgr.joinRoom('Close', 'fine:r', wsClose)
+    await mgr.joinRoom('Far', 'fine:r', wsFar)
+
+    const room = (mgr as any).rooms.get('fine:r').instance as FineGrainedRoom
+    room.setMemberWorldPosition('A', 0, 0, 0)        // chunk 0:0:0
+    room.setMemberWorldPosition('Close', 12, 0, 0)   // chunk 1:0:0 (within range=2)
+    room.setMemberWorldPosition('Far', 50, 0, 0)     // chunk 6:0:0 (out of range)
+
+    wsA._sent.length = 0
+    wsClose._sent.length = 0
+    wsFar._sent.length = 0
+
+    const sent = room.emitInChunkRange('A', 'tick', { n: 1 })
+    expect(sent).toBe(1)
+    expect(wsClose._sent.length).toBe(1)
+    expect(wsFar._sent.length).toBe(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('ChunkRoom — diagnostics', () => {
+  it('getMemberChunk returns the chunk coord after setMemberChunk', async () => {
+    const { mgr, reg } = makeManager()
+    reg.register(MinecraftRoom as any)
+    await mgr.joinRoom('alice', 'mc:r', mockWs('alice'))
+    const room = (mgr as any).rooms.get('mc:r').instance as MinecraftRoom
+    room.setMemberChunk('alice', [7, -3, 11])
+    expect(room.getMemberChunk('alice')).toEqual([7, -3, 11])
+  })
+
+  it('getMemberChunk returns undefined for unplaced member', async () => {
+    const { mgr, reg } = makeManager()
+    reg.register(MinecraftRoom as any)
+    await mgr.joinRoom('ghost', 'mc:r', mockWs('ghost'))
+    const room = (mgr as any).rooms.get('mc:r').instance as MinecraftRoom
+    expect(room.getMemberChunk('ghost')).toBeUndefined()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('ChunkRoom — scale', () => {
+  it('1000 players spread across a 100×100×100 chunk world, broadcast reaches small subset', async () => {
+    const { mgr, reg } = makeManager()
+    reg.register(MinecraftRoom as any)
+    const wsList: any[] = []
+    for (let i = 0; i < 1000; i++) {
+      const ws = mockWs(`p${i}`)
+      wsList.push(ws)
+      await mgr.joinRoom(`p${i}`, 'mc:r', ws)
+    }
+    const room = (mgr as any).rooms.get('mc:r').instance as MinecraftRoom
+    // Spread 1000 players over chunk coords in [0,30)³ → 27000 cells, density ~0.04/cell.
+    for (let i = 0; i < 1000; i++) {
+      room.setMemberChunk(`p${i}`, [(i * 17) % 30, (i * 23) % 30, (i * 29) % 30])
+    }
+
+    for (const ws of wsList) ws._sent.length = 0
+
+    // Place p0 at a known dense spot and broadcast.
+    room.setMemberChunk('p0', [15, 15, 15])
+    for (const ws of wsList) ws._sent.length = 0
+
+    const sent = room.emitInChunkRange('p0', 'chat', { from: 'p0', text: 'hi' })
+    expect(sent).toBeLessThan(100) // far below 999
+    console.log(`    [chunk-scale] 1000 players over 30³ chunks, broadcast reached ${sent} peers (${(sent / 1000 * 100).toFixed(1)}% of room)`)
+  })
+})

--- a/packages/spatial-room/src/__tests__/SpatialGrid.test.ts
+++ b/packages/spatial-room/src/__tests__/SpatialGrid.test.ts
@@ -1,0 +1,218 @@
+// SpatialGrid — pure data-structure tests. No LiveRoom coupling.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { SpatialGrid } from '../SpatialGrid'
+
+describe('SpatialGrid — construction', () => {
+  it('defaults to 2D with cellSize=100, defaultRange=1', () => {
+    const g = new SpatialGrid()
+    expect(g.dimensions).toBe(2)
+    expect(g.cellSize).toBe(100)
+    expect(g.defaultRange).toBe(1)
+  })
+
+  it('accepts 3D configuration', () => {
+    const g = new SpatialGrid({ dimensions: 3, cellSize: 50, defaultRange: 2 })
+    expect(g.dimensions).toBe(3)
+    expect(g.cellSize).toBe(50)
+    expect(g.defaultRange).toBe(2)
+  })
+
+  it('rejects non-positive cellSize', () => {
+    expect(() => new SpatialGrid({ cellSize: 0 })).toThrow(/cellSize/)
+    expect(() => new SpatialGrid({ cellSize: -1 })).toThrow(/cellSize/)
+    expect(() => new SpatialGrid({ cellSize: NaN })).toThrow(/cellSize/)
+    expect(() => new SpatialGrid({ cellSize: Infinity })).toThrow(/cellSize/)
+  })
+
+  it('rejects negative or non-integer defaultRange', () => {
+    expect(() => new SpatialGrid({ defaultRange: -1 })).toThrow(/defaultRange/)
+    expect(() => new SpatialGrid({ defaultRange: 1.5 })).toThrow(/defaultRange/)
+  })
+})
+
+describe('SpatialGrid — position math', () => {
+  it('positionToCellKey rounds DOWN to cell (Math.floor)', () => {
+    const g = new SpatialGrid({ cellSize: 100 })
+    expect(g.positionToCellKey([0, 0])).toBe('0:0')
+    expect(g.positionToCellKey([99.9, 50])).toBe('0:0')
+    expect(g.positionToCellKey([100, 100])).toBe('1:1')
+    expect(g.positionToCellKey([-1, -1])).toBe('-1:-1') // floor(-0.01) = -1
+    expect(g.positionToCellKey([-100.5, 0])).toBe('-2:0')
+  })
+
+  it('positionToCellKey works in 3D', () => {
+    const g = new SpatialGrid({ dimensions: 3, cellSize: 10 })
+    expect(g.positionToCellKey([5, 15, 25])).toBe('0:1:2')
+  })
+})
+
+describe('SpatialGrid — setPosition / getCell / remove', () => {
+  let g: SpatialGrid<string>
+  beforeEach(() => { g = new SpatialGrid({ cellSize: 100 }) })
+
+  it('adds a new member and reports its cell', () => {
+    g.setPosition('alice', [50, 50])
+    expect(g.getCell('alice')).toBe('0:0')
+    expect(g.size).toBe(1)
+    expect(g.cellCount).toBe(1)
+  })
+
+  it('moving inside the same cell returns false and is a no-op', () => {
+    g.setPosition('alice', [10, 10])
+    expect(g.setPosition('alice', [90, 90])).toBe(false)
+    expect(g.getCell('alice')).toBe('0:0')
+  })
+
+  it('crossing a cell boundary returns true and updates indexes', () => {
+    g.setPosition('alice', [50, 50])
+    expect(g.setPosition('alice', [150, 50])).toBe(true)
+    expect(g.getCell('alice')).toBe('1:0')
+    // Old cell is gone
+    expect(g.cellCount).toBe(1)
+  })
+
+  it('remove() cleans both the cell index and the membership map', () => {
+    g.setPosition('alice', [50, 50])
+    g.remove('alice')
+    expect(g.has('alice')).toBe(false)
+    expect(g.getCell('alice')).toBeUndefined()
+    expect(g.size).toBe(0)
+    expect(g.cellCount).toBe(0)
+  })
+
+  it('remove() on unknown member is a no-op', () => {
+    expect(() => g.remove('ghost')).not.toThrow()
+  })
+
+  it('two members in the same cell coexist; removing one keeps the cell', () => {
+    g.setPosition('alice', [10, 10])
+    g.setPosition('bob', [20, 20])
+    expect(g.cellCount).toBe(1)
+    g.remove('alice')
+    expect(g.cellCount).toBe(1) // cell still has bob
+  })
+
+  it('clear() resets everything', () => {
+    g.setPosition('alice', [10, 10])
+    g.setPosition('bob', [200, 200])
+    g.clear()
+    expect(g.size).toBe(0)
+    expect(g.cellCount).toBe(0)
+  })
+})
+
+describe('SpatialGrid.neighborCells — iteration', () => {
+  it('range=0 yields exactly the cell containing pos (2D)', () => {
+    const g = new SpatialGrid({ cellSize: 100 })
+    const cells = [...g.neighborCells([50, 50], 0)]
+    expect(cells).toEqual(['0:0'])
+  })
+
+  it('range=1 yields a 3×3 neighborhood (9 cells) in 2D', () => {
+    const g = new SpatialGrid({ cellSize: 100 })
+    const cells = [...g.neighborCells([150, 150], 1)]
+    expect(cells.length).toBe(9)
+    // Center is 1:1; range 0:0..2:2
+    expect(cells.sort()).toEqual([
+      '0:0', '0:1', '0:2',
+      '1:0', '1:1', '1:2',
+      '2:0', '2:1', '2:2',
+    ])
+  })
+
+  it('range=2 yields 5×5 = 25 cells in 2D', () => {
+    const g = new SpatialGrid({ cellSize: 100 })
+    expect([...g.neighborCells([0, 0], 2)].length).toBe(25)
+  })
+
+  it('range=1 yields 3×3×3 = 27 cells in 3D', () => {
+    const g = new SpatialGrid({ dimensions: 3, cellSize: 100 })
+    expect([...g.neighborCells([0, 0, 0], 1)].length).toBe(27)
+  })
+})
+
+describe('SpatialGrid.queryNear — proximity query by position', () => {
+  let g: SpatialGrid<string>
+  beforeEach(() => {
+    g = new SpatialGrid({ cellSize: 100 })
+    g.setPosition('alice', [50, 50])    // cell 0:0
+    g.setPosition('bob', [150, 50])     // cell 1:0
+    g.setPosition('carol', [350, 350])  // cell 3:3 (far away)
+  })
+
+  it('returns near members with range=1 (3×3)', () => {
+    const near = g.queryNear([50, 50], 1)
+    expect(near.has('alice')).toBe(true)
+    expect(near.has('bob')).toBe(true) // adjacent cell
+    expect(near.has('carol')).toBe(false)
+  })
+
+  it('range=0 only returns same-cell members', () => {
+    const near = g.queryNear([50, 50], 0)
+    expect(near.has('alice')).toBe(true)
+    expect(near.has('bob')).toBe(false)
+  })
+
+  it('range=4 picks up carol too', () => {
+    const near = g.queryNear([50, 50], 4)
+    expect(near.has('carol')).toBe(true)
+  })
+
+  it('returns an empty Set if no one is nearby', () => {
+    const isolated = new SpatialGrid({ cellSize: 100 })
+    isolated.setPosition('lonely', [9999, 9999])
+    expect(isolated.queryNear([0, 0], 1).size).toBe(0)
+  })
+})
+
+describe('SpatialGrid.queryNearMember — "broadcast to peers near me"', () => {
+  it('excludes the querier by default', () => {
+    const g = new SpatialGrid({ cellSize: 100 })
+    g.setPosition('alice', [50, 50])
+    g.setPosition('bob', [50, 50])
+    const near = g.queryNearMember('alice')
+    expect(near.has('alice')).toBe(false)
+    expect(near.has('bob')).toBe(true)
+  })
+
+  it('can include self via flag', () => {
+    const g = new SpatialGrid({ cellSize: 100 })
+    g.setPosition('alice', [50, 50])
+    const near = g.queryNearMember('alice', 1, false)
+    expect(near.has('alice')).toBe(true)
+  })
+
+  it('returns empty set if member has no position', () => {
+    const g = new SpatialGrid({ cellSize: 100 })
+    expect(g.queryNearMember('ghost').size).toBe(0)
+  })
+
+  it('works in 3D', () => {
+    const g = new SpatialGrid({ dimensions: 3, cellSize: 10 })
+    g.setPosition('a', [0, 0, 0])
+    g.setPosition('b', [5, 5, 5])    // same cell 0:0:0
+    g.setPosition('c', [15, 0, 0])   // adjacent cell 1:0:0
+    g.setPosition('far', [100, 100, 100])
+
+    const near = g.queryNearMember('a', 1)
+    expect(near.has('b')).toBe(true)
+    expect(near.has('c')).toBe(true)
+    expect(near.has('far')).toBe(false)
+  })
+})
+
+describe('SpatialGrid — stress / scale (100 members)', () => {
+  it('100 random positions, query range=1 returns a reasonable subset', () => {
+    const g = new SpatialGrid({ cellSize: 100 })
+    // Spread 100 members across a 1000×1000 map (10×10 cells)
+    for (let i = 0; i < 100; i++) {
+      g.setPosition(`m${i}`, [(i * 71) % 1000, (i * 113) % 1000])
+    }
+    expect(g.size).toBe(100)
+    const near = g.queryNear([500, 500], 1)
+    // 3×3 cells out of ~100 cells, expected ~9% of members
+    expect(near.size).toBeGreaterThan(0)
+    expect(near.size).toBeLessThan(100)
+  })
+})

--- a/packages/spatial-room/src/__tests__/SpatialLiveRoom.test.ts
+++ b/packages/spatial-room/src/__tests__/SpatialLiveRoom.test.ts
@@ -1,0 +1,308 @@
+// SpatialLiveRoom — end-to-end test against the real LiveRoomManager.
+// Verifies that emitNearby() only delivers to members in the surrounding
+// cells, that movement reindexes correctly, and that onLeave cleans up.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { LiveRoomManager, RoomRegistry, RoomEventBus } from '@fluxstack/live'
+import { SpatialLiveRoom } from '../SpatialLiveRoom'
+
+// LiveWSData type is internal — we mimic the shape the manager expects.
+type AnyWS = any
+
+vi.mock('@fluxstack/live', async () => {
+  const actual = await vi.importActual<any>('@fluxstack/live')
+  return actual
+})
+
+function mockWs(id: string) {
+  // Stores raw frames AND a parsed-event view for binary deliveries. The
+  // codec path is msgpack/json-binary; we only assert that *some* frame
+  // arrived and (optionally) what its high-level shape is.
+  const sent: any[] = []
+  const data = {
+    connectionId: id,
+    components: new Map(),
+    subscriptions: new Set(),
+    connectedAt: new Date(),
+    userId: undefined,
+    authContext: { authenticated: false, session: undefined,
+      hasRole: () => false, hasAnyRole: () => false, hasAllRoles: () => false,
+      hasPermission: () => false, hasAllPermissions: () => false, hasAnyPermission: () => false } as any,
+  }
+  return {
+    send: (m: any) => { sent.push(m) },
+    close: () => {},
+    data,
+    remoteAddress: '127.0.0.1',
+    readyState: 1 as const,
+    _sent: sent,
+  } as AnyWS
+}
+
+// ── Test rooms ──────────────────────────────────────────────────────────
+
+interface PlayerState {
+  players: Record<string, { x: number; y: number }>
+}
+
+class Arena extends SpatialLiveRoom<PlayerState, any, { moved: { id: string; x: number; y: number } }> {
+  static roomName = 'arena'
+  static defaultState: PlayerState = { players: {} }
+  static spatial = { dimensions: 2 as const, cellSize: 100, defaultRange: 1 }
+  // Force JSON codec so the test mock WS can introspect message contents.
+  // (Default for typed LiveRooms is msgpack binary.)
+  static $options = { codec: 'json' as const }
+
+  move(componentId: string, x: number, y: number): number {
+    this.setMemberPosition(componentId, [x, y])
+    this.state.players[componentId] = { x, y }
+    return this.emitNearby(componentId, 'moved', { id: componentId, x, y })
+  }
+}
+
+class World3D extends SpatialLiveRoom<{}, any, { ping: { from: string } }> {
+  static roomName = 'world3d'
+  static defaultState = {}
+  static spatial = { dimensions: 3 as const, cellSize: 10, defaultRange: 1 }
+
+  place(componentId: string, x: number, y: number, z: number) {
+    this.setMemberPosition(componentId, [x, y, z])
+  }
+
+  ping(senderId: string): number {
+    return this.emitNearby(senderId, 'ping', { from: senderId })
+  }
+}
+
+function makeManager() {
+  const mgr = new LiveRoomManager(new RoomEventBus())
+  const reg = new RoomRegistry()
+  mgr.roomRegistry = reg
+  return { mgr, reg }
+}
+
+let consoleSpy: ReturnType<typeof vi.spyOn>
+beforeEach(() => { consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {}) })
+afterEach(() => { consoleSpy?.mockRestore() })
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('SpatialLiveRoom — basic interest filtering', () => {
+  it('only sends emitNearby to members in adjacent cells', async () => {
+    const { mgr, reg } = makeManager()
+    reg.register(Arena as any)
+
+    const wsA = mockWs('A')
+    const wsB = mockWs('B')
+    const wsFar = mockWs('FAR')
+    await mgr.joinRoom('A', 'arena:r', wsA)
+    await mgr.joinRoom('B', 'arena:r', wsB)
+    await mgr.joinRoom('FAR', 'arena:r', wsFar)
+
+    const room = (mgr as any).rooms.get('arena:r').instance as Arena
+    room.move('A', 50, 50)        // cell 0:0
+    room.move('B', 150, 50)       // cell 1:0 — adjacent to A
+    room.move('FAR', 1000, 1000)  // far away
+
+    wsA._sent.length = 0
+    wsB._sent.length = 0
+    wsFar._sent.length = 0
+
+    const sent = room.move('A', 60, 60) // A moves slightly within cell 0:0
+    // emitNearby excludes self by default → only B receives, not A, not FAR
+    expect(sent).toBe(1)
+    expect(wsA._sent.length).toBe(0)
+    expect(wsB._sent.length).toBe(1)
+    expect(wsFar._sent.length).toBe(0)
+  })
+
+  it('crossing cells changes who is visible', async () => {
+    const { mgr, reg } = makeManager()
+    reg.register(Arena as any)
+
+    const wsA = mockWs('A')
+    const wsB = mockWs('B')
+    const wsC = mockWs('C')
+    await mgr.joinRoom('A', 'arena:r', wsA)
+    await mgr.joinRoom('B', 'arena:r', wsB)
+    await mgr.joinRoom('C', 'arena:r', wsC)
+
+    const room = (mgr as any).rooms.get('arena:r').instance as Arena
+    room.move('A', 50, 50)        // cell 0:0
+    room.move('B', 150, 50)       // cell 1:0 — adjacent
+    room.move('C', 500, 500)      // cell 5:5 — far
+
+    // Reset send counters
+    wsA._sent.length = 0
+    wsB._sent.length = 0
+    wsC._sent.length = 0
+
+    // A moves far to (490, 490) — now adjacent to C (cell 4:4)
+    const sent1 = room.move('A', 490, 490)
+    // Now A's neighbors include C (cells 4:4-5:5 within range=1 of A's 4:4)
+    expect(sent1).toBe(1)
+    expect(wsC._sent.length).toBe(1)
+    expect(wsB._sent.length).toBe(0)
+  })
+
+  it('falls back to global emit when sender has no recorded position', async () => {
+    const { mgr, reg } = makeManager()
+    reg.register(Arena as any)
+    const wsA = mockWs('A')
+    const wsB = mockWs('B')
+    await mgr.joinRoom('A', 'arena:r', wsA)
+    await mgr.joinRoom('B', 'arena:r', wsB)
+
+    const room = (mgr as any).rooms.get('arena:r').instance as Arena
+    // Reset send counters after the join handshake so we only count the emit.
+    wsA._sent.length = 0
+    wsB._sent.length = 0
+
+    // No setMemberPosition for 'A'. emitNearby falls back to room.emit() which
+    // broadcasts to ALL members (LiveRoom.emit doesn't exclude any sender).
+    const sent = room.emitNearby('A', 'moved' as any, { id: 'A', x: 0, y: 0 })
+    expect(sent).toBe(2) // both A and B receive
+    expect(wsA._sent.length).toBe(1)
+    expect(wsB._sent.length).toBe(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('SpatialLiveRoom — emitAtPosition', () => {
+  it('reaches members near an arbitrary world point (no sender)', async () => {
+    const { mgr, reg } = makeManager()
+    reg.register(Arena as any)
+    const wsA = mockWs('A')
+    const wsB = mockWs('B')
+    await mgr.joinRoom('A', 'arena:r', wsA)
+    await mgr.joinRoom('B', 'arena:r', wsB)
+
+    const room = (mgr as any).rooms.get('arena:r').instance as Arena
+    room.setMemberPosition('A', [50, 50])      // cell 0:0
+    room.setMemberPosition('B', [9999, 9999])  // far
+
+    wsA._sent.length = 0
+    wsB._sent.length = 0
+
+    const sent = room.emitAtPosition([100, 100], 'moved' as any, { id: 'BOMB', x: 100, y: 100 })
+    expect(sent).toBe(1) // only A is near
+    expect(wsA._sent.length).toBe(1)
+    expect(wsB._sent.length).toBe(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('SpatialLiveRoom — 3D', () => {
+  it('filters by 3D proximity', async () => {
+    const { mgr, reg } = makeManager()
+    reg.register(World3D as any)
+    const wsA = mockWs('A')
+    const wsB = mockWs('B')
+    const wsFar = mockWs('FAR')
+    await mgr.joinRoom('A', 'world3d:r', wsA)
+    await mgr.joinRoom('B', 'world3d:r', wsB)
+    await mgr.joinRoom('FAR', 'world3d:r', wsFar)
+
+    const room = (mgr as any).rooms.get('world3d:r').instance as World3D
+    room.place('A', 5, 5, 5)        // 0:0:0
+    room.place('B', 15, 5, 5)       // 1:0:0 — adjacent
+    room.place('FAR', 0, 0, 100)    // 0:0:10 — out of range
+
+    wsA._sent.length = 0
+    wsB._sent.length = 0
+    wsFar._sent.length = 0
+
+    const sent = room.ping('A')
+    expect(sent).toBe(1)
+    expect(wsB._sent.length).toBe(1)
+    expect(wsFar._sent.length).toBe(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('SpatialLiveRoom — cleanup on leave', () => {
+  it('onLeave removes the member from the spatial grid', async () => {
+    const { mgr, reg } = makeManager()
+    reg.register(Arena as any)
+    const wsA = mockWs('A')
+    await mgr.joinRoom('A', 'arena:r', wsA)
+    const room = (mgr as any).rooms.get('arena:r').instance as Arena
+    room.setMemberPosition('A', [50, 50])
+    expect(room.getOccupiedCellCount()).toBe(1)
+
+    await mgr.leaveRoom('A', 'arena:r')
+    expect(room.getOccupiedCellCount()).toBe(0)
+  })
+
+  it('cleanupComponent (abrupt disconnect) also removes from grid', async () => {
+    const { mgr, reg } = makeManager()
+    reg.register(Arena as any)
+    const wsA = mockWs('A')
+    await mgr.joinRoom('A', 'arena:r', wsA)
+    const room = (mgr as any).rooms.get('arena:r').instance as Arena
+    room.setMemberPosition('A', [50, 50])
+
+    await mgr.cleanupComponent('A')
+    expect(room.getOccupiedCellCount()).toBe(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('SpatialLiveRoom — diagnostics', () => {
+  it('getVisibleMembers returns the live interest set', async () => {
+    const { mgr, reg } = makeManager()
+    reg.register(Arena as any)
+    await mgr.joinRoom('A', 'arena:r', mockWs('A'))
+    await mgr.joinRoom('B', 'arena:r', mockWs('B'))
+    await mgr.joinRoom('C', 'arena:r', mockWs('C'))
+
+    const room = (mgr as any).rooms.get('arena:r').instance as Arena
+    room.setMemberPosition('A', [50, 50])
+    room.setMemberPosition('B', [50, 50])
+    room.setMemberPosition('C', [9999, 9999])
+
+    const visible = room.getVisibleMembers('A')
+    expect(visible.has('B')).toBe(true)
+    expect(visible.has('A')).toBe(false) // self excluded
+    expect(visible.has('C')).toBe(false)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+describe('SpatialLiveRoom — scale (the whole reason this exists)', () => {
+  it('1000 members, broadcasting from one spot only reaches a small subset', async () => {
+    const { mgr, reg } = makeManager()
+    reg.register(Arena as any)
+
+    const wsList: any[] = []
+    for (let i = 0; i < 1000; i++) {
+      const ws = mockWs(`p${i}`)
+      wsList.push(ws)
+      await mgr.joinRoom(`p${i}`, 'arena:r', ws)
+    }
+    const room = (mgr as any).rooms.get('arena:r').instance as Arena
+    // Scatter 1000 players over a 1000×1000 world (cellSize=100 → 10×10 = 100 cells).
+    // Average ~10 players per cell → 3×3 neighborhood ~= 90 expected.
+    for (let i = 0; i < 1000; i++) {
+      room.setMemberPosition(`p${i}`, [(i * 37) % 1000, (i * 89) % 1000])
+    }
+
+    // Reset send counters
+    for (const ws of wsList) ws._sent.length = 0
+
+    // Pick a sender that we know is at a populated spot.
+    room.setMemberPosition('p0', [500, 500])
+    for (const ws of wsList) ws._sent.length = 0
+
+    const sent = room.move('p0', 500, 500)
+    // Expected: a tiny fraction of 1000, NOT all 999. The exact number
+    // depends on PRNG-like distribution, but should be well under 100.
+    expect(sent).toBeLessThan(100)
+    expect(sent).toBeGreaterThanOrEqual(0)
+
+    // Quantify the win:
+    const recipientsActuallyHit = wsList.filter(w => w._sent.length > 0).length
+    // (sent counts deliveries; recipientsActuallyHit confirms the count maps to distinct WSs)
+    expect(recipientsActuallyHit).toBe(sent)
+    console.log(`    [scale] 1000 members in 1000×1000 world (cellSize=100), broadcast reached ${sent} peers (${(sent / 1000 * 100).toFixed(1)}% of room — vs 100% without spatial)`)
+  })
+})

--- a/packages/spatial-room/src/index.ts
+++ b/packages/spatial-room/src/index.ts
@@ -1,0 +1,3 @@
+export { SpatialGrid, type Position, type Vec2, type Vec3, type SpatialGridOptions } from './SpatialGrid'
+export { SpatialLiveRoom, type SpatialRoomConfig } from './SpatialLiveRoom'
+export { ChunkRoom, chunkToWorld, worldToChunk, type ChunkCoord } from './ChunkRoom'

--- a/packages/spatial-room/tsconfig.json
+++ b/packages/spatial-room/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/spatial-room/tsup.config.ts
+++ b/packages/spatial-room/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: 'es2022',
+  external: ['@fluxstack/live'],
+})

--- a/packages/spatial-room/vitest.config.ts
+++ b/packages/spatial-room/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'spatial-room',
+    globals: true,
+    environment: 'node',
+    include: ['src/__tests__/**/*.test.ts'],
+  },
+})

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -9,5 +9,6 @@ export default defineWorkspace([
   'packages/fastify',
   'packages/client',
   'packages/react',
+  'packages/spatial-room',
   '__tests__',
 ])


### PR DESCRIPTION
## Summary

New optional package that replaces O(N) broadcast with O(visible cells) for games where players only need updates from nearby peers. Ships two ready-to-use room classes plus a low-level grid for custom use.

### \`SpatialLiveRoom\` (2D or 3D — default 2D)

Drop-in replacement for \`LiveRoom\`. Adds:
- \`setMemberPosition(id, pos)\` — place/move a member in the grid
- \`emitNearby(senderId, event, data)\` — broadcast only to peers in the surrounding cells (default 3×3 in 2D, 27 cells in 3D)
- \`emitAtPosition(pos, event, data)\` — server-originated events at an arbitrary world point (\"explosion at X\")
- \`getVisibleMembers(id)\` — diagnostic for the interest set

### \`ChunkRoom\` extends \`SpatialLiveRoom\` (3D, Minecraft-style)

Defaults: \`dimensions=3\`, \`cellSize=16\` (Minecraft chunk), \`range=1\` (3×3×3 = 27 chunks visible). Adds chunk-aware helpers:
- \`setMemberChunk(id, [cx, cy, cz])\` — place by chunk coord
- \`emitInChunkRange / emitAtChunk\` — chunk-named emits
- \`chunkToWorld / worldToChunk\` utility functions

### \`SpatialGrid\` (low-level, no LiveRoom coupling)

Pure data structure for proximity queries — useful for NPCs/AI/server-side bots independent of a room.

## Core changes (additive, non-breaking)

- \`LiveRoomManager.emitToRoomMembers(roomId, ids, event, data)\` — new public method used by SpatialLiveRoom to deliver to a subset. Uses the same per-member splice/binary encoding as the full broadcast path, so wire format is identical.
- \`LiveRoomManagerInterface\` declares the new method as optional so plugins can call it.

## Measured impact (in the suite)

| Scenario | Without spatial | With spatial | Reduction |
|---|---|---|---|
| 2D, 1000 players in 1000×1000 world (cellSize=100) | 999 sends | **86 sends** | **91%** |
| 3D voxel, 1000 players in 30³ chunks (view distance 1) | 999 sends | **33 sends** | **97%** |

## Tests (+47)

- **SpatialGrid.test.ts** (26): construction, position math, setPosition cell-move semantics, remove cleanup, range=0..N neighborhoods, 2D/3D queryNear / queryNearMember, 100-member stress.
- **SpatialLiveRoom.test.ts** (9): only-nearby emit, cell-crossing changes who is visible, fallback to global emit when no position, emitAtPosition with no sender, 3D filtering, onLeave + abrupt disconnect cleanup, diagnostics, 1000-player scale check.
- **ChunkRoom.test.ts** (12): chunkToWorld/worldToChunk round-trip, defaults, setMemberWorldPosition vs setMemberChunk, emitInChunkRange with view distance 1 and 2, emitAtChunk (no sender), fine-grained cellSize, getMemberChunk diagnostics, 1000-player chunk-scale.

## Test plan

- [x] All 47 new tests pass
- [x] Full suite: **1463 passing** (was 1416, +47), Redis included, 0 failures
- [x] Typecheck clean across all packages
- [x] Package builds (\`bunx tsup\` in \`packages/spatial-room\`)
- [x] No breaking changes to core — only one new optional method on the interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)